### PR TITLE
use MultiAddress type in parachain

### DIFF
--- a/rococo-parachains/runtime/src/lib.rs
+++ b/rococo-parachains/runtime/src/lib.rs
@@ -27,7 +27,7 @@ use sp_api::impl_runtime_apis;
 use sp_core::OpaqueMetadata;
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
-	traits::{BlakeTwo256, Block as BlockT, IdentityLookup, Verify},
+	traits::{AccountIdLookup, BlakeTwo256, Block as BlockT, Verify},
 	transaction_validity::{TransactionSource, TransactionValidity},
 	ApplyExtrinsicResult,
 	MultiSignature
@@ -167,7 +167,7 @@ impl frame_system::Config for Runtime {
 	/// The aggregated dispatch type that is available for extrinsics.
 	type Call = Call;
 	/// The lookup mechanism to get account ID from whatever is passed in dispatchers.
-	type Lookup = IdentityLookup<AccountId>;
+	type Lookup = AccountIdLookup<AccountId, ()>;
 	/// The index type for storing how many extrinsics an account has signed.
 	type Index = Index;
 	/// The index type for blocks.
@@ -361,7 +361,7 @@ construct_runtime! {
 }
 
 /// The address format for describing accounts.
-pub type Address = AccountId;
+pub type Address = sp_runtime::MultiAddress<AccountId, ()>;
 /// Block header type as expected by this runtime.
 pub type Header = generic::Header<BlockNumber, BlakeTwo256>;
 /// Block type as expected by this runtime.

--- a/rococo-parachains/runtime/src/lib.rs
+++ b/rococo-parachains/runtime/src/lib.rs
@@ -373,6 +373,7 @@ pub type BlockId = generic::BlockId<Block>;
 /// The SignedExtension to the basic transaction logic.
 pub type SignedExtra = (
 	frame_system::CheckSpecVersion<Runtime>,
+	frame_system::CheckTxVersion<Runtime>,
 	frame_system::CheckGenesis<Runtime>,
 	frame_system::CheckEra<Runtime>,
 	frame_system::CheckNonce<Runtime>,

--- a/rococo-parachains/src/chain_spec.rs
+++ b/rococo-parachains/src/chain_spec.rs
@@ -123,8 +123,19 @@ pub fn staging_test_net(id: ParaId) -> ChainSpec {
 	)
 }
 
-pub fn rococo_test_net(id: ParaId, root: Option<AccountId>) -> ChainSpec {
-	let root_key = root.unwrap_or_else(|| get_account_id_from_seed::<sr25519::Public>("Alice"));
+pub fn rococo_test_net(id: ParaId, use_well_known_keys: bool) -> ChainSpec {
+	// encointer_root
+	let mut root_account: AccountId =  hex!["107f9c5385955bc57ac108b46b36498c4a8348eb964258b9b2ac53797d94794b"].into();
+	let mut endowed_accounts = vec![root_account.clone()];
+
+	if use_well_known_keys {
+		root_account = get_account_id_from_seed::<sr25519::Public>("Alice");
+		endowed_accounts = vec![
+			get_account_id_from_seed::<sr25519::Public>("Alice"),
+			get_account_id_from_seed::<sr25519::Public>("Bob"),
+			get_account_id_from_seed::<sr25519::Public>("Charlie"),
+		];
+	}
 
 	ChainSpec::from_genesis(
 		"Encointer Rococo",
@@ -132,10 +143,8 @@ pub fn rococo_test_net(id: ParaId, root: Option<AccountId>) -> ChainSpec {
 		ChainType::Live,
 		move || {
 			testnet_genesis(
-				root_key.clone(),
-				vec![
-					root_key.clone(),
-				],
+				root_account.clone(),
+				endowed_accounts.clone(),
 				id,
 			)
 		},

--- a/rococo-parachains/src/chain_spec.rs
+++ b/rococo-parachains/src/chain_spec.rs
@@ -123,7 +123,8 @@ pub fn staging_test_net(id: ParaId) -> ChainSpec {
 	)
 }
 
-pub fn rococo_test_net(id: ParaId) -> ChainSpec {
+pub fn rococo_test_net(id: ParaId, root: Option<AccountId>) -> ChainSpec {
+	let root_key = root.unwrap_or_else(|| get_account_id_from_seed::<sr25519::Public>("Alice"));
 
 	ChainSpec::from_genesis(
 		"Encointer Rococo",
@@ -131,9 +132,9 @@ pub fn rococo_test_net(id: ParaId) -> ChainSpec {
 		ChainType::Live,
 		move || {
 			testnet_genesis(
-				hex!["107f9c5385955bc57ac108b46b36498c4a8348eb964258b9b2ac53797d94794b"].into(),
+				root_key.clone(),
 				vec![
-					hex!["107f9c5385955bc57ac108b46b36498c4a8348eb964258b9b2ac53797d94794b"].into(),
+					root_key.clone(),
 				],
 				id,
 			)

--- a/rococo-parachains/src/command.rs
+++ b/rococo-parachains/src/command.rs
@@ -20,6 +20,7 @@ use crate::{
 };
 use codec::Encode;
 use cumulus_primitives::{genesis::generate_genesis_block, ParaId};
+use hex_literal::hex;
 use log::info;
 use parachain_runtime::Block;
 use polkadot_parachain::primitives::AccountIdConversion;
@@ -41,7 +42,14 @@ fn load_spec(
 ) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 	match id {
 		"staging" => Ok(Box::new(chain_spec::staging_test_net(para_id))),
-		"encointer-rococo" => Ok(Box::new(chain_spec::rococo_test_net(para_id))),
+		"encointer-rococo" => Ok(Box::new(chain_spec::rococo_test_net(
+            para_id,
+            Some(hex!["107f9c5385955bc57ac108b46b36498c4a8348eb964258b9b2ac53797d94794b"].into()),
+		))),
+		"encointer-rococo-alice" => Ok(Box::new(chain_spec::rococo_test_net(
+            para_id,
+            None
+        ))),
 		"tick" => Ok(Box::new(chain_spec::ChainSpec::from_json_bytes(
 			&include_bytes!("../res/tick.json")[..],
 		)?)),

--- a/rococo-parachains/src/command.rs
+++ b/rococo-parachains/src/command.rs
@@ -20,7 +20,6 @@ use crate::{
 };
 use codec::Encode;
 use cumulus_primitives::{genesis::generate_genesis_block, ParaId};
-use hex_literal::hex;
 use log::info;
 use parachain_runtime::Block;
 use polkadot_parachain::primitives::AccountIdConversion;
@@ -42,14 +41,8 @@ fn load_spec(
 ) -> std::result::Result<Box<dyn sc_service::ChainSpec>, String> {
 	match id {
 		"staging" => Ok(Box::new(chain_spec::staging_test_net(para_id))),
-		"encointer-rococo" => Ok(Box::new(chain_spec::rococo_test_net(
-            para_id,
-            Some(hex!["107f9c5385955bc57ac108b46b36498c4a8348eb964258b9b2ac53797d94794b"].into()),
-		))),
-		"encointer-rococo-alice" => Ok(Box::new(chain_spec::rococo_test_net(
-            para_id,
-            None
-        ))),
+		"encointer-rococo" => Ok(Box::new(chain_spec::rococo_test_net(para_id, false))),
+		"encointer-rococo-well-known-keys" => Ok(Box::new(chain_spec::rococo_test_net(para_id, true))),
 		"tick" => Ok(Box::new(chain_spec::ChainSpec::from_json_bytes(
 			&include_bytes!("../res/tick.json")[..],
 		)?)),


### PR DESCRIPTION
* Use `MultiAddress` type
* Added chain_spec cmd with Alice as root_key that endows some well-known keys.

* Tested with local setup as in README
* encointer-client 's `bootstrate_demo_currency.sh` script run successfully.