### PR TITLE
expose encointer's custom RPCs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2089,6 +2089,12 @@ dependencies = [
  "launch-runtime",
  "log",
  "nix",
+ "pallet-encointer-bazaar-rpc",
+ "pallet-encointer-bazaar-rpc-runtime-api",
+ "pallet-encointer-ceremonies-rpc",
+ "pallet-encointer-ceremonies-rpc-runtime-api",
+ "pallet-encointer-communities-rpc",
+ "pallet-encointer-communities-rpc-runtime-api",
  "pallet-transaction-payment-rpc",
  "parachains-common",
  "parity-scale-codec",
@@ -2180,8 +2186,11 @@ dependencies = [
  "pallet-collective",
  "pallet-encointer-balances",
  "pallet-encointer-bazaar",
+ "pallet-encointer-bazaar-rpc-runtime-api",
  "pallet-encointer-ceremonies",
+ "pallet-encointer-ceremonies-rpc-runtime-api",
  "pallet-encointer-communities",
+ "pallet-encointer-communities-rpc-runtime-api",
  "pallet-encointer-scheduler",
  "pallet-membership",
  "pallet-proxy",
@@ -5514,6 +5523,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-encointer-bazaar-rpc"
+version = "0.1.0"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.17#51f3daedbf251b9b34ffdc1753f9fa0d04cf5f12"
+dependencies = [
+ "encointer-primitives",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "log",
+ "pallet-encointer-bazaar-rpc-runtime-api",
+ "parking_lot 0.12.0",
+ "sc-rpc",
+ "sc-rpc-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-encointer-bazaar-rpc-runtime-api"
+version = "0.1.0"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.17#51f3daedbf251b9b34ffdc1753f9fa0d04cf5f12"
+dependencies = [
+ "encointer-primitives",
+ "frame-support",
+ "sp-api",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-encointer-ceremonies"
 version = "0.8.1"
 source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.17#51f3daedbf251b9b34ffdc1753f9fa0d04cf5f12"
@@ -5537,6 +5576,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "pallet-encointer-ceremonies-rpc"
+version = "0.1.0"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.17#51f3daedbf251b9b34ffdc1753f9fa0d04cf5f12"
+dependencies = [
+ "encointer-primitives",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "log",
+ "pallet-encointer-ceremonies-rpc-runtime-api",
+ "parking_lot 0.12.0",
+ "sc-rpc",
+ "sc-rpc-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-encointer-ceremonies-rpc-runtime-api"
+version = "0.1.0"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.17#51f3daedbf251b9b34ffdc1753f9fa0d04cf5f12"
+dependencies = [
+ "encointer-primitives",
+ "frame-support",
+ "sp-api",
+ "sp-std",
+]
+
+[[package]]
 name = "pallet-encointer-communities"
 version = "0.8.1"
 source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.17#51f3daedbf251b9b34ffdc1753f9fa0d04cf5f12"
@@ -5552,6 +5621,35 @@ dependencies = [
  "scale-info",
  "sp-io",
  "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-encointer-communities-rpc"
+version = "0.1.0"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.17#51f3daedbf251b9b34ffdc1753f9fa0d04cf5f12"
+dependencies = [
+ "encointer-primitives",
+ "jsonrpc-core",
+ "jsonrpc-core-client",
+ "jsonrpc-derive",
+ "log",
+ "pallet-encointer-communities-rpc-runtime-api",
+ "parking_lot 0.12.0",
+ "sc-rpc",
+ "sc-rpc-api",
+ "sp-api",
+ "sp-blockchain",
+ "sp-runtime",
+]
+
+[[package]]
+name = "pallet-encointer-communities-rpc-runtime-api"
+version = "0.1.0"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.17#51f3daedbf251b9b34ffdc1753f9fa0d04cf5f12"
+dependencies = [
+ "encointer-primitives",
+ "sp-api",
  "sp-std",
 ]
 
@@ -11045,7 +11143,7 @@ dependencies = [
  "chrono",
  "lazy_static",
  "matchers",
- "parking_lot 0.11.2",
+ "parking_lot 0.10.2",
  "regex",
  "serde",
  "serde_json",
@@ -11166,7 +11264,7 @@ version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee73e6e4924fe940354b8d4d98cad5231175d615cd855b758adc658c0aac6a0"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if 0.1.10",
  "rand 0.8.5",
  "static_assertions",
 ]

--- a/polkadot-launch/launch-rococo-local-with-encointer-and-sybil-dummy.json
+++ b/polkadot-launch/launch-rococo-local-with-encointer-and-sybil-dummy.json
@@ -30,7 +30,14 @@
 					"wsPort": 9944,
 					"port": 31200,
 					"name": "alice",
-					"flags": ["-lencointer=debug", "--", "--execution=wasm"]
+					"flags": [
+						"--force-authoring",
+						"--enable-offchain-indexing=true",
+						"--rpc-methods=unsafe",
+						"-lencointer=debug",
+						"--",
+						"--execution=wasm"
+					]
 				}
 			]
 		},

--- a/polkadot-launch/launch-rococo-with-encointer-and-sybil-dummy.json
+++ b/polkadot-launch/launch-rococo-with-encointer-and-sybil-dummy.json
@@ -29,7 +29,13 @@
 				{
 					"wsPort": 9944,
 					"port": 31200,
-					"flags": ["-lencointer=debug", "--", "--execution=wasm"]
+					"flags": [
+						"--enable-offchain-indexing=true",
+						"--rpc-methods=unsafe",
+						"-lencointer=debug",
+						"--",
+						"--execution=wasm"
+					]
 				}
 			]
 		},

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -27,6 +27,14 @@ parachain-runtime = { package = "encointer-runtime", path = "encointer-runtime" 
 launch-runtime = { package = "launch-runtime", path = "launch-runtime" }
 parachains-common = { path = "parachains-common" }
 
+# encointer dependencies
+pallet-encointer-ceremonies-rpc = { git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17"}
+pallet-encointer-ceremonies-rpc-runtime-api = { git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17"}
+pallet-encointer-communities-rpc = { git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17"}
+pallet-encointer-communities-rpc-runtime-api = { git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17"}
+pallet-encointer-bazaar-rpc = {git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17"}
+pallet-encointer-bazaar-rpc-runtime-api = {git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17"}
+
 # Substrate dependencies
 frame-benchmarking = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17" }
 frame-benchmarking-cli = { git = "https://github.com/paritytech/substrate", branch = "polkadot-v0.9.17" }

--- a/polkadot-parachains/encointer-runtime/Cargo.toml
+++ b/polkadot-parachains/encointer-runtime/Cargo.toml
@@ -15,12 +15,15 @@ scale-info = { version = "1.0.0", default-features = false, features = ["derive"
 serde = { version = "1.0.132", default-features = false, optional = true, features = ["derive"] }
 
 # encointer deps
-encointer-primitives = { default-features = false, features = ['serde_derive'], git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
-pallet-encointer-scheduler = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
-pallet-encointer-ceremonies = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
-pallet-encointer-communities = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
+encointer-primitives = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
 pallet-encointer-balances = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
 pallet-encointer-bazaar = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
+pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
+pallet-encointer-ceremonies = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
+pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
+pallet-encointer-communities = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
+pallet-encointer-communities-rpc-runtime-api = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
+pallet-encointer-scheduler = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
 #pallet-encointer-personhood-oracle = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
 #pallet-encointer-sybil-gate-template = { default-features = false, git = "https://github.com/encointer/pallets", branch = "polkadot-v0.9.17" }
 
@@ -133,11 +136,14 @@ std = [
 	"serde/std",
 	"encointer-primitives/std",
 	"encointer-primitives/serde_derive",
-	"pallet-encointer-scheduler/std",
-	"pallet-encointer-ceremonies/std",
 	"pallet-encointer-balances/std",
-	"pallet-encointer-communities/std",
 	"pallet-encointer-bazaar/std",
+	"pallet-encointer-bazaar-rpc-runtime-api/std",
+	"pallet-encointer-ceremonies/std",
+	"pallet-encointer-ceremonies-rpc-runtime-api/std",
+	"pallet-encointer-communities/std",
+	"pallet-encointer-communities-rpc-runtime-api/std",
+	"pallet-encointer-scheduler/std",
 #	"pallet-encointer-personhood-oracle/std",
 #	"pallet-encointer-sybil-gate-template/std",
 ]

--- a/polkadot-parachains/encointer-runtime/src/lib.rs
+++ b/polkadot-parachains/encointer-runtime/src/lib.rs
@@ -85,6 +85,10 @@ pub use pallet_encointer_scheduler::Call as EncointerSchedulerCall;
 
 pub use encointer_primitives::{
 	balances::{BalanceEntry, BalanceType, Demurrage},
+	bazaar::{BusinessData, BusinessIdentifier, OfferingData},
+	ceremonies::{CeremonyIndexType, CommunityReputation},
+	common::PalletString,
+	communities::{CommunityIdentifier, Location},
 	scheduler::CeremonyPhaseType,
 };
 
@@ -938,6 +942,41 @@ impl_runtime_apis! {
 			ParachainSystem::collect_collation_info(header)
 		}
 	}
+
+	impl pallet_encointer_ceremonies_rpc_runtime_api::CeremoniesApi<Block, AccountId> for Runtime {
+		fn get_reputations(account: &AccountId) -> Vec<(CeremonyIndexType, CommunityReputation)> {
+			EncointerCeremonies::get_reputations(&account)
+		}
+	}
+
+	impl pallet_encointer_communities_rpc_runtime_api::CommunitiesApi<Block, AccountId, BlockNumber> for Runtime {
+		fn get_all_balances(account: &AccountId) -> Vec<(CommunityIdentifier, BalanceEntry<BlockNumber>)> {
+			EncointerCommunities::get_all_balances(account)
+		}
+
+		fn get_cids() -> Vec<CommunityIdentifier> {
+			EncointerCommunities::get_cids()
+		}
+
+		fn get_name(cid: &CommunityIdentifier) -> Option<PalletString> {
+			EncointerCommunities::get_name(cid)
+		}
+
+		fn get_locations(cid: &CommunityIdentifier) -> Vec<Location> {
+			EncointerCommunities::get_locations(cid)
+		}
+	}
+
+	impl pallet_encointer_bazaar_rpc_runtime_api::BazaarApi<Block, AccountId> for Runtime {
+		fn get_offerings(business: &BusinessIdentifier<AccountId>) -> Vec<OfferingData>{
+			EncointerBazaar::get_offerings(business)
+		}
+
+		fn get_businesses(community: &CommunityIdentifier) -> Vec<(AccountId, BusinessData)>{
+			EncointerBazaar::get_businesses(community)
+		}
+	}
+
 
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {

--- a/polkadot-parachains/encointer-runtime/src/lib.rs
+++ b/polkadot-parachains/encointer-runtime/src/lib.rs
@@ -977,7 +977,6 @@ impl_runtime_apis! {
 		}
 	}
 
-
 	#[cfg(feature = "runtime-benchmarks")]
 	impl frame_benchmarking::Benchmark<Block> for Runtime {
 		fn benchmark_metadata(extra: bool) -> (

--- a/polkadot-parachains/src/command.rs
+++ b/polkadot-parachains/src/command.rs
@@ -26,7 +26,6 @@ use codec::Encode;
 use cumulus_client_service::genesis::generate_genesis_block;
 use cumulus_primitives_core::ParaId;
 use log::info;
-use parachains_common::AuraId;
 use polkadot_parachain::primitives::AccountIdConversion;
 use sc_cli::{
 	ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
@@ -425,23 +424,15 @@ pub fn run() -> Result<()> {
 				info!("Is collating: {}", if config.role.is_authority() { "yes" } else { "no" });
 
 				if config.chain_spec.is_launch() {
-					crate::service::start_parachain_node::<
-						launch_runtime::RuntimeApi,
-						LaunchParachainRuntimeExecutor,
-						AuraId,
-					>(config, polkadot_config, id)
-					.await
-					.map(|r| r.0)
-					.map_err(Into::into)
+					crate::service::start_launch_node(config, polkadot_config, id)
+						.await
+						.map(|r| r.0)
+						.map_err(Into::into)
 				} else {
-					crate::service::start_parachain_node::<
-						parachain_runtime::RuntimeApi,
-						EncointerParachainRuntimeExecutor,
-						AuraId,
-					>(config, polkadot_config, id)
-					.await
-					.map(|r| r.0)
-					.map_err(Into::into)
+					crate::service::start_encointer_node(config, polkadot_config, id)
+						.await
+						.map(|r| r.0)
+						.map_err(Into::into)
 				}
 			})
 		},

--- a/polkadot-parachains/src/rpc.rs
+++ b/polkadot-parachains/src/rpc.rs
@@ -33,17 +33,21 @@ use parachains_common::{AccountId, Balance, Block, Index as Nonce};
 pub type RpcExtension = jsonrpc_core::IoHandler<sc_rpc::Metadata>;
 
 /// Full client dependencies
-pub struct FullDeps<C, P> {
+pub struct FullDeps<C, P, Backend> {
 	/// The client instance to use.
 	pub client: Arc<C>,
 	/// Transaction pool instance.
 	pub pool: Arc<P>,
+	/// backend instance used to access offchain storage (added by encointer).
+	pub backend: Arc<Backend>,
+	/// whether offchain-indexing is enabled (added by encointer).
+	pub offchain_indexing_enabled: bool,
 	/// Whether to deny unsafe calls
 	pub deny_unsafe: DenyUnsafe,
 }
 
 /// Instantiate all RPC extensions.
-pub fn create_full<C, P>(deps: FullDeps<C, P>) -> RpcExtension
+pub fn create_full<C, P, TBackend>(deps: FullDeps<C, P, TBackend>) -> RpcExtension
 where
 	C: ProvideRuntimeApi<Block>
 		+ HeaderBackend<Block>
@@ -56,15 +60,36 @@ where
 	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
 	C::Api: BlockBuilder<Block>,
 	P: TransactionPool + Sync + Send + 'static,
+	C::Api: pallet_encointer_ceremonies_rpc_runtime_api::CeremoniesApi<Block, AccountId>,
+	C::Api:
+		pallet_encointer_communities_rpc_runtime_api::CommunitiesApi<Block, AccountId, BlockNumber>,
+	C::Api: pallet_encointer_bazaar_rpc_runtime_api::BazaarApi<Block, AccountId>,
+	TBackend: sc_client_api::Backend<Block>, // added by encointer
+	<TBackend as sc_client_api::Backend<Block>>::OffchainStorage: 'static, // added by encointer
 {
 	use frame_rpc_system::{FullSystem, SystemApi};
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
 
 	let mut io = jsonrpc_core::IoHandler::default();
-	let FullDeps { client, pool, deny_unsafe } = deps;
+	let FullDeps { client, pool, backend, offchain_indexing_enabled, deny_unsafe } = deps;
 
 	io.extend_with(SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe)));
 	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone())));
+
+	io.extend_with(BazaarApi::to_delegate(Bazaar::new(client.clone(), deny_unsafe)));
+	io.extend_with(CeremoniesApi::to_delegate(Ceremonies::new(client.clone(), deny_unsafe)));
+
+	match backend.offchain_storage() {
+		Some(storage) => io.extend_with(CommunitiesApi::to_delegate(Communities::new(
+			client.clone(),
+			storage,
+			offchain_indexing_enabled,
+			deny_unsafe,
+		))),
+		None => log::warn!(
+			"Offchain caching disabled, due to lack of offchain storage support in backend."
+		),
+	};
 
 	io
 }

--- a/polkadot-parachains/src/rpc.rs
+++ b/polkadot-parachains/src/rpc.rs
@@ -27,7 +27,10 @@ use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
 use sp_blockchain::{Error as BlockChainError, HeaderBackend, HeaderMetadata};
 
-use parachains_common::{AccountId, Balance, Block, Index as Nonce};
+use pallet_encointer_bazaar_rpc::{Bazaar, BazaarApi};
+use pallet_encointer_ceremonies_rpc::{Ceremonies, CeremoniesApi};
+use pallet_encointer_communities_rpc::{Communities, CommunitiesApi};
+use parachains_common::{AccountId, Balance, Block, BlockNumber, Index as Nonce};
 
 /// A type representing all RPC extensions.
 pub type RpcExtension = jsonrpc_core::IoHandler<sc_rpc::Metadata>;
@@ -90,6 +93,43 @@ where
 			"Offchain caching disabled, due to lack of offchain storage support in backend."
 		),
 	};
+
+	io
+}
+
+// /// Full client dependencies need for shell
+// pub struct ShellDeps<C, P, Backend> {
+// 	/// The client instance to use.
+// 	pub client: Arc<C>,
+// 	/// Transaction pool instance.
+// 	pub pool: Arc<P>,
+// 	/// Whether to deny unsafe calls
+// 	pub deny_unsafe: DenyUnsafe,
+// }
+
+/// Instantiate all RPC extensions.
+pub fn create_shell<C, P, TBackend>(deps: FullDeps<C, P, TBackend>) -> RpcExtension
+where
+	C: ProvideRuntimeApi<Block>
+		+ HeaderBackend<Block>
+		+ AuxStore
+		+ HeaderMetadata<Block, Error = BlockChainError>
+		+ Send
+		+ Sync
+		+ 'static,
+	C::Api: frame_rpc_system::AccountNonceApi<Block, AccountId, Nonce>,
+	C::Api: pallet_transaction_payment_rpc::TransactionPaymentRuntimeApi<Block, Balance>,
+	C::Api: BlockBuilder<Block>,
+	P: TransactionPool + Sync + Send + 'static,
+{
+	use frame_rpc_system::{FullSystem, SystemApi};
+	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
+
+	let mut io = jsonrpc_core::IoHandler::default();
+	let FullDeps { client, pool, backend, offchain_indexing_enabled, deny_unsafe } = deps;
+
+	io.extend_with(SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe)));
+	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone())));
 
 	io
 }

--- a/polkadot-parachains/src/rpc.rs
+++ b/polkadot-parachains/src/rpc.rs
@@ -97,18 +97,8 @@ where
 	io
 }
 
-// /// Full client dependencies need for shell
-// pub struct ShellDeps<C, P, Backend> {
-// 	/// The client instance to use.
-// 	pub client: Arc<C>,
-// 	/// Transaction pool instance.
-// 	pub pool: Arc<P>,
-// 	/// Whether to deny unsafe calls
-// 	pub deny_unsafe: DenyUnsafe,
-// }
-
-/// Instantiate all RPC extensions.
-pub fn create_shell<C, P, TBackend>(deps: FullDeps<C, P, TBackend>) -> RpcExtension
+/// Instantiate reduced RPC extensions for launch runtime
+pub fn create_launch_ext<C, P, TBackend>(deps: FullDeps<C, P, TBackend>) -> RpcExtension
 where
 	C: ProvideRuntimeApi<Block>
 		+ HeaderBackend<Block>

--- a/polkadot-parachains/src/rpc.rs
+++ b/polkadot-parachains/src/rpc.rs
@@ -126,7 +126,7 @@ where
 	use pallet_transaction_payment_rpc::{TransactionPayment, TransactionPaymentApi};
 
 	let mut io = jsonrpc_core::IoHandler::default();
-	let FullDeps { client, pool, backend, offchain_indexing_enabled, deny_unsafe } = deps;
+	let FullDeps { client, pool, backend: _, offchain_indexing_enabled: _, deny_unsafe } = deps;
 
 	io.extend_with(SystemApi::to_delegate(FullSystem::new(client.clone(), pool, deny_unsafe)));
 	io.extend_with(TransactionPaymentApi::to_delegate(TransactionPayment::new(client.clone())));

--- a/polkadot-parachains/src/service.rs
+++ b/polkadot-parachains/src/service.rs
@@ -220,7 +220,7 @@ async fn start_node_impl<RuntimeApi, Executor, RB, BIQ, BIC>(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,
 	id: ParaId,
-	rpc_ext: RB,
+	rpc_extensions: RB,
 	build_import_queue: BIQ,
 	build_consensus: BIC,
 ) -> sc_service::error::Result<(
@@ -342,7 +342,7 @@ where
 				deny_unsafe,
 			};
 
-			rpc_ext(deps)
+			rpc_extensions(deps)
 		})
 	};
 
@@ -807,7 +807,7 @@ pub async fn start_launch_node(
 		LaunchParachainRuntimeExecutor,
 		parachains_common::AuraId,
 		_,
-	>(config, polkadot_config, id, |deps| Ok(rpc::create_shell(deps)))
+	>(config, polkadot_config, id, |deps| Ok(rpc::create_launch_ext(deps)))
 	.await
 }
 

--- a/polkadot-parachains/src/service.rs
+++ b/polkadot-parachains/src/service.rs
@@ -322,11 +322,16 @@ where
 	let rpc_extensions_builder = {
 		let client = client.clone();
 		let transaction_pool = transaction_pool.clone();
+		let backend = backend.clone();
+		let offchain_indexing_enabled = config.offchain_worker.indexing_enabled;
 
+		// `backend` and offchain_indexing_enabled` are encointer customizations.
 		Box::new(move |deny_unsafe, _| {
 			let deps = rpc::FullDeps {
 				client: client.clone(),
 				pool: transaction_pool.clone(),
+				backend: backend.clone(),
+				offchain_indexing_enabled,
 				deny_unsafe,
 			};
 

--- a/polkadot-parachains/src/service.rs
+++ b/polkadot-parachains/src/service.rs
@@ -323,7 +323,7 @@ where
 		let client = client.clone();
 		let transaction_pool = transaction_pool.clone();
 		let backend = backend.clone();
-		let offchain_indexing_enabled = config.offchain_worker.indexing_enabled;
+		let offchain_indexing_enabled = parachain_config.offchain_worker.indexing_enabled;
 
 		// `backend` and offchain_indexing_enabled` are encointer customizations.
 		Box::new(move |deny_unsafe, _| {
@@ -335,7 +335,7 @@ where
 				deny_unsafe,
 			};
 
-			Ok(rpc::create_full(deps))
+			Ok(rpc::create_shell(deps))
 		})
 	};
 
@@ -764,5 +764,51 @@ where
 			Ok(parachain_consensus)
 		},
 	)
+	.await
+}
+
+/// Start a node containing the launch runtime
+pub async fn start_launch_node(
+	config: Configuration,
+	polkadot_config: Configuration,
+	id: ParaId,
+) -> sc_service::error::Result<(
+	TaskManager,
+	Arc<
+		TFullClient<
+			Block,
+			launch_runtime::RuntimeApi,
+			NativeElseWasmExecutor<LaunchParachainRuntimeExecutor>,
+		>,
+	>,
+)> {
+	start_parachain_node::<
+		launch_runtime::RuntimeApi,
+		LaunchParachainRuntimeExecutor,
+		parachains_common::AuraId,
+	>(config, polkadot_config, id)
+	.await
+}
+
+/// Start a node containing the encointer runtime.
+pub async fn start_encointer_node(
+	config: Configuration,
+	polkadot_config: Configuration,
+	id: ParaId,
+) -> sc_service::error::Result<(
+	TaskManager,
+	Arc<
+		TFullClient<
+			Block,
+			parachain_runtime::RuntimeApi,
+			NativeElseWasmExecutor<EncointerParachainRuntimeExecutor>,
+		>,
+	>,
+)> {
+	start_parachain_node::<
+		parachain_runtime::RuntimeApi,
+		EncointerParachainRuntimeExecutor,
+		parachains_common::AuraId,
+	>(config, polkadot_config, id)
 	.await
 }


### PR DESCRIPTION
* Closes #107 

Changes: 
* Expose encointers RPCs (only possible with encointer-runtime)
* rococo-local setup:  add offchain-indexing and unsafe rpc flag to expose the encointer RPCs

Tested:
* That the new RPCs are in the RPC-list in polkadot-js.