### PR TITLE
Make demurrage computation sound; bump pallets and versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2159,7 +2159,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-collator"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2281,7 +2281,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-runtime"
-version = "1.3.12"
+version = "1.3.13"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "launch-runtime"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2134,7 +2134,7 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2150,7 +2150,7 @@ dependencies = [
 [[package]]
 name = "encointer-ceremonies-assignment"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -2241,7 +2241,7 @@ dependencies = [
 [[package]]
 name = "encointer-meetup-validation"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -2254,7 +2254,7 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "bs58",
  "crc",
@@ -2273,7 +2273,7 @@ dependencies = [
 [[package]]
 name = "encointer-rpc"
 version = "0.1.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "jsonrpsee",
  "thiserror",
@@ -2414,7 +2414,7 @@ checksum = "68b91989ae21441195d7d9b9993a2f9295c7e1a8c96255d8b729accddc124797"
 [[package]]
 name = "ep-core"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -5628,7 +5628,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -5647,7 +5647,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -5664,7 +5664,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -5683,7 +5683,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "1.0.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -5694,7 +5694,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-meetup-validation",
@@ -5719,7 +5719,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -5738,7 +5738,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -5749,7 +5749,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -5768,7 +5768,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -5787,7 +5787,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "1.2.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "sp-api",
@@ -5797,7 +5797,7 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "1.1.0"
-source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#3fc6c4fcef549d32e0ed7beb73ac940b43b25af3"
+source = "git+https://github.com/encointer/pallets?branch=polkadot-v0.9.28#f859dff21f9c9fd3863f6eaa5cf64cd1f827c7af"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",

--- a/polkadot-parachains/Cargo.toml
+++ b/polkadot-parachains/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "encointer-collator"
 # align major.minor revision with the runtimes. bump patch revision ad lib. make this the github release tag
-version = "1.3.2"
+version = "1.3.3"
 authors = ["Encointer <info@encointer.org>"]
 build = "build.rs"
 edition = "2021"

--- a/polkadot-parachains/encointer-runtime/Cargo.toml
+++ b/polkadot-parachains/encointer-runtime/Cargo.toml
@@ -2,7 +2,7 @@
 name = 'encointer-runtime'
 # major.minor revision must match collator node
 # patch revision must match runtime spec_version
-version = '1.3.12'
+version = '1.3.13'
 authors = ["Encointer <info@encointer.org>"]
 license = "GPL-3.0"
 edition = "2021"

--- a/polkadot-parachains/encointer-runtime/src/lib.rs
+++ b/polkadot-parachains/encointer-runtime/src/lib.rs
@@ -119,7 +119,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("encointer-parachain"),
 	impl_name: create_runtime_str!("encointer-parachain"),
 	authoring_version: 1,
-	spec_version: 12,
+	spec_version: 13,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 2,

--- a/polkadot-parachains/launch-runtime/Cargo.toml
+++ b/polkadot-parachains/launch-runtime/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = 'launch-runtime'
 # major.minor revision must match collator node. patch should match the runtimes' `spec_version`.
-version = '1.3.2'
+version = '1.3.3'
 authors = ["Encointer <info@encointer.org>"]
 license = "GPL-3.0"
 edition = "2021"

--- a/polkadot-parachains/launch-runtime/src/lib.rs
+++ b/polkadot-parachains/launch-runtime/src/lib.rs
@@ -96,7 +96,7 @@ pub const VERSION: RuntimeVersion = RuntimeVersion {
 	spec_name: create_runtime_str!("encointer-parachain"),
 	impl_name: create_runtime_str!("encointer-parachain"),
 	authoring_version: 1,
-	spec_version: 2,
+	spec_version: 3,
 	impl_version: 1,
 	apis: RUNTIME_API_VERSIONS,
 	transaction_version: 1,


### PR DESCRIPTION
This includes the important PR to prevent demurrage from overflowing: https://github.com/encointer/pallets/pull/298