### PR TITLE
Add gatotech bootnode to Kusama's Encointer

### DIFF
--- a/polkadot-parachains/res/encointer-kusama.json
+++ b/polkadot-parachains/res/encointer-kusama.json
@@ -1,7 +1,10 @@
 {
   "bootNodes": [
     "/ip4/104.248.131.111/tcp/30333/p2p/12D3KooWGa6QRfYmeCWCBHPvJAytaiXZsWzuq1L7zgzph4YHwGjB",
-    "/ip4/104.248.135.198/tcp/30333/p2p/12D3KooWCSzi8TmqvxKmrPdXT5jietrRMCeDVQGZUWQ5JT6MpZ9F"
+    "/ip4/104.248.135.198/tcp/30333/p2p/12D3KooWCSzi8TmqvxKmrPdXT5jietrRMCeDVQGZUWQ5JT6MpZ9F",
+    "/dns/boot-ksm-encointer-cr.gatotech.network/tcp/31326/p2p/12D3KooWByfCkLUzuMBJhVqb5SZxTHgGdwPzbJEk3t7gxDUakdi7",
+    "/dns/boot-ksm-encointer-cr.gatotech.network/tcp/31426/ws/p2p/12D3KooWByfCkLUzuMBJhVqb5SZxTHgGdwPzbJEk3t7gxDUakdi7",
+    "/dns/boot-ksm-encointer-cr.gatotech.network/tcp/31526/wss/p2p/12D3KooWByfCkLUzuMBJhVqb5SZxTHgGdwPzbJEk3t7gxDUakdi7"
   ],
   "chainType": "Live",
   "codeSubstitutes": {},


### PR DESCRIPTION
Dear team, hello,

Please consider the following changes so Encointer in Kusama can benefits from an additional bootnode:

also, please note this bootnode can be tested using the below commands:

```
encointer-collator --no-hardware-benchmarks --no-mdns --chain encointer-kusama --reserved-only --reserved-nodes "/dns/boot-ksm-encointer-cr.gatotech.network/tcp/31326/p2p/12D3KooWByfCkLUzuMBJhVqb5SZxTHgGdwPzbJEk3t7gxDUakdi7"

encointer-collator --no-hardware-benchmarks --no-mdns --chain encointer-kusama --reserved-only --reserved-nodes "/dns/boot-ksm-encointer-cr.gatotech.network/tcp/31426/ws/p2p/12D3KooWByfCkLUzuMBJhVqb5SZxTHgGdwPzbJEk3t7gxDUakdi7"

encointer-collator --no-hardware-benchmarks --no-mdns --chain encointer-kusama --reserved-only --reserved-nodes "/dns/boot-ksm-encointer-cr.gatotech.network/tcp/31526/wss/p2p/12D3KooWByfCkLUzuMBJhVqb5SZxTHgGdwPzbJEk3t7gxDUakdi7"
```

Many thanks, have a nice week ahead!

Sincerelly,

**_Miloš_**