### PR TITLE
Add bootnode to Encointer in Kusama - gatotech

### DIFF
--- a/polkadot-parachains/res/encointer-kusama.json
+++ b/polkadot-parachains/res/encointer-kusama.json
@@ -8,6 +8,8 @@
     "/dns/kusama-encointer-boot-ng.dwellir.com/tcp/30342/p2p/12D3KooWMKBdoj1y5yxpPRsuioAuLDeYGyZFJw1aL1dDbBvWMrvx",
     "/dns/boot-node.helikon.io/tcp/10240/p2p/12D3KooWA911RYTs2DdsA1EkxviUo12DdAdJ9Zsaf8S5PpQzeRGA",
     "/dns/boot-node.helikon.io/tcp/10242/wss/p2p/12D3KooWA911RYTs2DdsA1EkxviUo12DdAdJ9Zsaf8S5PpQzeRGA",
+    "/dns/boot-cr.gatotech.network/tcp/33220/p2p/12D3KooWByfCkLUzuMBJhVqb5SZxTHgGdwPzbJEk3t7gxDUakdi7",
+    "/dns/boot-cr.gatotech.network/tcp/35220/wss/p2p/12D3KooWByfCkLUzuMBJhVqb5SZxTHgGdwPzbJEk3t7gxDUakdi7",
     "/dns/encointer-kusama-bootnode.turboflakes.io/tcp/30625/p2p/12D3KooWCXoAM2ucUEhMhLkZVWJ6hMCHqV2K4sjVM27t5ZGv4XU6",
     "/dns/encointer-kusama-bootnode.turboflakes.io/tcp/30725/wss/p2p/12D3KooWCXoAM2ucUEhMhLkZVWJ6hMCHqV2K4sjVM27t5ZGv4XU6"
   ],


### PR DESCRIPTION
Dear @brenzi, dear team, hello,

Thanks for your kind observations to Pull Request #165, this proposal now supersedes it.

This request proposes to add one bootnode (with two endpoints) to the Encointer parachain of the Kusama network.

Both endpoints have been thoroughly tested using:

1. for vanilla connections over p2p:
```
encointer-collator --no-hardware-benchmarks --no-mdns --chain encointer-kusama --reserved-only --reserved-nodes "/dns/boot-cr.gatotech.network/tcp/33220/p2p/12D3KooWByfCkLUzuMBJhVqb5SZxTHgGdwPzbJEk3t7gxDUakdi7"
```

2. for secured websocket (wss) connections over p2p:
```
encointer-collator --no-hardware-benchmarks --no-mdns --chain encointer-kusama --reserved-only --reserved-nodes "/dns/boot-cr.gatotech.network/tcp/35220/wss/p2p/12D3KooWByfCkLUzuMBJhVqb5SZxTHgGdwPzbJEk3t7gxDUakdi7"
```

many thanks for considering this merge to the project!

 Have a great week ahead!

Best regards

**_Milos_**