### PR TITLE
upgrade to polkadot-sdk-v1.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - '[0-9]+.[0-9]+.[0-9]+'
+      - '[0-9]+.[0-9]+.[0-9]+*'
   pull_request:
     branches: [master]
   workflow_dispatch:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -122,15 +122,6 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
@@ -239,9 +230,9 @@ dependencies = [
 
 [[package]]
 name = "aquamarine"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "074b80d14d0240b6ce94d68f059a2d26a5d77280ae142662365a21ef6e2594ef"
+checksum = "21cc1548309245035eb18aa7f0967da6bc65587005170c56e6ef2788a4cf3f4e"
 dependencies = [
  "include_dir",
  "itertools 0.10.5",
@@ -377,7 +368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94893f1e0c6eeab764ade8dc4c0db24caf4fe7cbbaafc0eba0a9030f447b5185"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -715,9 +706,9 @@ dependencies = [
 
 [[package]]
 name = "binary-merkle-tree"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf2706ac2641485d35ed06ebfe0b3b2c43e19a7ad8a90215580a91dd1766114"
+checksum = "2bf857f8f411164ce1af14a778626af96251de7a77837711efbc440807e7053f"
 dependencies = [
  "hash-db",
  "log",
@@ -760,7 +751,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f2635620bf0b9d4576eb7bb9a38a55df78bd1205d26fa994b25911a69f212f"
 dependencies = [
  "bitcoin_hashes",
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
  "serde",
  "unicode-normalization",
@@ -920,9 +911,9 @@ dependencies = [
 
 [[package]]
 name = "bounded-collections"
-version = "0.1.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca548b6163b872067dc5eb82fd130c56881435e30367d2073594a3d9744120dd"
+checksum = "d32385ecb91a31bddaf908e8dcf4a15aef1bcd3913cc03ebfad02ff6d568abc1"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -941,9 +932,9 @@ dependencies = [
 
 [[package]]
 name = "bp-xcm-bridge-hub-router"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f58cd5d7880f4bc8fc569e5bb0174302cd3f7e18a322e0fec2a4733cced35cb"
+checksum = "86ff4abe93be7bc1663adc41817b1aa3476fbec953ce361537419924310d5dd4"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -1328,12 +1319,12 @@ checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "comfy-table"
-version = "7.0.1"
+version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ab77dbd8adecaf3f0db40581631b995f312a8a5ae3aa9993188bb8f23d83a5b"
+checksum = "7c64043d6c7b7a4c58e39e7efccfdea7b93d885a795d0c054a69dbbf4dd52686"
 dependencies = [
- "strum",
- "strum_macros",
+ "strum 0.25.0",
+ "strum_macros 0.25.3",
  "unicode-width",
 ]
 
@@ -1354,15 +1345,15 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.7"
+version = "0.15.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c926e00cc70edefdc64d3a5ff31cc65bb97a3460097762bd23afb4d8145fccf8"
+checksum = "0e1f83fc076bd6dd27517eacdf25fef6c4dfe5f1d7448bafaaf3a26f13b5e4eb"
 dependencies = [
  "encode_unicode",
  "lazy_static",
  "libc",
  "unicode-width",
- "windows-sys 0.45.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1730,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-cli"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88972dcd58e7d411ebfd9d82d7399aad567afe737ba8ad0943abfaf1a8b3903b"
+checksum = "70d2597fe3235d263457aaff65d0fb5bed506698b81530e2e6afecd6d6c9af32"
 dependencies = [
  "clap",
  "parity-scale-codec",
@@ -1748,9 +1739,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-collator"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab9d9114479da745e34b1a4529dca9e51a61860593b61681107249bc68024bd4"
+checksum = "3c06ae72a125d056da3b722f00f87881a2afbb2af8fe9fa9a91587f139b9667e"
 dependencies = [
  "cumulus-client-consensus-common",
  "cumulus-client-network",
@@ -1772,9 +1763,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-aura"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00378c991116820c354713b3d3be2c9789f84bfb86d0a3c97676cc9e8a39c174"
+checksum = "18f4977f6a88af39c46832d571ac0d95e8322bf22eab42550fec34f72da9f034"
 dependencies = [
  "async-trait",
  "cumulus-client-collator",
@@ -1815,9 +1806,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-common"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385c403c208f654e276f6d7ae30316d3d64f0975c9e19a18ed5943a963cc48c6"
+checksum = "350db1fc8841a44f344474b791d2ebe61b79bf6061043a7d826b3d02d1935a56"
 dependencies = [
  "async-trait",
  "cumulus-client-pov-recovery",
@@ -1845,9 +1836,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-proposer"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614b239940f64843c65ec19e157ee769c556f74f084077dc2f0425f0a671e9ba"
+checksum = "38028f75597a34d447f059d6a7fd9c1c91bce0b8c48b08b1cbd19eb3def9c376"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1861,9 +1852,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-consensus-relay-chain"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad64cf7112d6a980ee69b58570cd1426c2a728082a5c42e13e82519f7acf4bf"
+checksum = "066792a42dd6c38315e5759be14509004e95215aa9455cf8e7f207d7ab656a7c"
 dependencies = [
  "async-trait",
  "cumulus-client-consensus-common",
@@ -1885,9 +1876,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-network"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee9b8802b76850237bbf2c1afb869a9673b49ef9545b31698e1bffbffcaa4254"
+checksum = "0ac095ef439c595ccb998be5a9d40778d8963c5a8ebbaed838fed6293232915b"
 dependencies = [
  "async-trait",
  "cumulus-relay-chain-interface",
@@ -1909,9 +1900,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-parachain-inherent"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bcc095540bb3ad848b1d5cd8708d8b493729370d4671df5a0c38ea53382e46b"
+checksum = "0b516290cd4a6efc117824135761f3642dc57685e13da00727c460053ce978fe"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1922,7 +1913,7 @@ dependencies = [
  "sc-client-api",
  "scale-info",
  "sp-api",
- "sp-core",
+ "sp-crypto-hashing",
  "sp-inherents",
  "sp-runtime",
  "sp-state-machine",
@@ -1934,9 +1925,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-pov-recovery"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd12cbdd57209ffc68d167b0c22c90d5680185b57d03e4c2436aef7dfd918a2"
+checksum = "b4d55e96004ca9aa9d9b96a28ab2d97b1ca8d303c9d2405ea34cdf1462d4c4f0"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -1948,7 +1939,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand 0.8.5",
+ "rand",
  "sc-client-api",
  "sc-consensus",
  "sp-consensus",
@@ -1959,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-client-service"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5be0615943319f8750eb54793f8ec8721b2081852c23ed450da54cfcf6aca97"
+checksum = "657f57c56159bb6cb74d9221de8f11c9e09962666381357896562662d3019799"
 dependencies = [
  "cumulus-client-cli",
  "cumulus-client-collator",
@@ -1996,9 +1987,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-aura-ext"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8100a3283be2c46905345141e9a063f092949c6630a1fb70993b04c97f309e55"
+checksum = "9e8e78b18548ae3454bc8a46e2bc2e3f521ea547844cbaecc9344d4741f4b1ef"
 dependencies = [
  "cumulus-pallet-parachain-system",
  "frame-support",
@@ -2015,9 +2006,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-dmp-queue"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f461956a4a85c053657fe64e73852940c8a52e7d8fc20ccb4f91688e73f0820b"
+checksum = "06ebf036bcb1e61c943cf588d14b903234594fb2538f2d7dae36e20fcc3c86e8"
 dependencies = [
  "cumulus-primitives-core",
  "frame-benchmarking",
@@ -2034,9 +2025,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-parachain-system"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1a0e6800ea92447eab2c9170cc77d21987fd0e61ed79a6e1318f7b127b3e2c"
+checksum = "1a215fe4d66d23e8f3956bd21b9d80d2b33239f3b150b36d56fa238cfc9421a5"
 dependencies = [
  "bytes",
  "cumulus-pallet-parachain-system-proc-macro",
@@ -2052,6 +2043,7 @@ dependencies = [
  "pallet-message-queue",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
+ "polkadot-runtime-common",
  "polkadot-runtime-parachains",
  "scale-info",
  "sp-core",
@@ -2081,9 +2073,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcm"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9e5e8dd3f9c98620e32cbb1783725a3e75a3147cb351b43de37663824311cd9"
+checksum = "8e802291060763f8d1176bf808da97aafe5afe7351f62bb093c317c1d35c5cee"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -2098,9 +2090,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-pallet-xcmp-queue"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439cdba45813623e7f45374f160f3356d27fb1aaca2536dd7f60ef2a7e9b30cd"
+checksum = "0fa22d6e479a4d3a2790bab291269ba0917a1ac384255a54a2ebc3f7c37e505e"
 dependencies = [
  "bounded-collections",
  "bp-xcm-bridge-hub-router",
@@ -2124,9 +2116,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-aura"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05ad9d2b1454d6957a92b3f8755d7bfa2b5b70ab2fa7751215f6897de5ac4cf6"
+checksum = "2f07d6177692154043d7ddcc0b87ca5365ae8e4d94b90d9931f6b2f76e162f09"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2139,9 +2131,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-core"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "036b64697b5fd04c8039ccf15b9891104c496afb6c418c2cea1234d4898d0a28"
+checksum = "9df07f6825fd50ea30aae335e43dc1a615a05de7465f5f329b9e414f2c886a12"
 dependencies = [
  "parity-scale-codec",
  "polkadot-core-primitives",
@@ -2157,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-parachain-inherent"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cb6fe06744fed6e84682c48816181ad63652003570c2135c425481440fcd2f2"
+checksum = "38ad140a065a6b8001fb26ec42b91391e90fde120f5b4e57986698249a9b98c8"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2173,9 +2165,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-primitives-proof-size-hostfunction"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a132e17ac2c79436bc5004b0d56cb35ca65b966434f14e5ff8a9bc1afcfca5a4"
+checksum = "c1b74f9141190b9f4bf96a947ade46da64097b77f1ebfa8d611c81724250e119"
 dependencies = [
  "sp-externalities",
  "sp-runtime-interface",
@@ -2183,29 +2175,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "cumulus-primitives-timestamp"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d1d900bd9e76607a4a0734cbb2b004d86177d2d6938b5d25eb812c6c1b7500"
-dependencies = [
- "cumulus-primitives-core",
- "futures 0.3.28",
- "parity-scale-codec",
- "sp-inherents",
- "sp-std",
- "sp-timestamp",
-]
-
-[[package]]
 name = "cumulus-primitives-utility"
-version = "0.7.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ece52eeb7e87faea0d374356571ebc13f279df3bf79a1dc8a0db6c49d6ba23"
+checksum = "e65466e56d642f979b556d098a03755ae51972fff5fa0f9b1cdcfdb3df062ea3"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
  "log",
- "pallet-xcm-benchmarks",
+ "pallet-asset-conversion",
  "parity-scale-codec",
  "polkadot-runtime-common",
  "polkadot-runtime-parachains",
@@ -2219,9 +2197,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-inprocess-interface"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6801c53e543614ce1b9f87cfca8ed69aab5318ba51439c0db8a910c8c3d77a15"
+checksum = "cff27dec2eab6cd1d854756d62bd7053721ccd115f36f9e8b0976b1e46b70ef7"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2244,9 +2222,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-interface"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdf9bd710caacdee77f50f01a40f37f8c9af1040e895de3e0b421f2c4ad0a291"
+checksum = "40c736f39b50eecf194707e15d0359677bb8fe8138b01f6493ab9b7e10d2d1ae"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2263,9 +2241,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-minimal-node"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b1e0847e45d6a5090ee32b4dc3497cb0671b9a6a9259f9a263a769560c5b60e"
+checksum = "4c7718fe298d567adc44fae3dd7024418d6eff08264041e4b0544d1892861cd6"
 dependencies = [
  "array-bytes 6.1.0",
  "async-trait",
@@ -2305,9 +2283,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-relay-chain-rpc-interface"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb8a4c98335aeac261bde9b21e7518c099bfacc96592a052750051cebda158c"
+checksum = "d8e2269d4c1f37593257b3d7b90f8b56adab0793d9b9f5c1b5334c9ca7e3b10b"
 dependencies = [
  "async-trait",
  "cumulus-primitives-core",
@@ -2319,7 +2297,7 @@ dependencies = [
  "parity-scale-codec",
  "pin-project",
  "polkadot-overseer",
- "rand 0.8.5",
+ "rand",
  "sc-client-api",
  "sc-rpc-api",
  "sc-service",
@@ -2345,9 +2323,9 @@ dependencies = [
 
 [[package]]
 name = "cumulus-test-relay-sproof-builder"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ec12490a40b00427119fd1e12a6d1fe0652d2df3e992dea1bc4f331effed12"
+checksum = "bfff604ad01c5c0c397f9a971c8cec6443aea3658813778875b4f64de07847d5"
 dependencies = [
  "cumulus-primitives-core",
  "parity-scale-codec",
@@ -2651,18 +2629,18 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "docify"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4235e9b248e2ba4b92007fe9c646f3adf0ffde16dc74713eacc92b8bc58d8d2f"
+checksum = "7cc4fd38aaa9fb98ac70794c82a00360d1e165a87fbf96a8a91f9dfc602aaee2"
 dependencies = [
  "docify_macros",
 ]
 
 [[package]]
 name = "docify_macros"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47020e12d7c7505670d1363dd53d6c23724f71a90a3ae32ff8eba40de8404626"
+checksum = "63fa215f3a0d40fb2a221b3aa90d8e1fbb8379785a990cb60d62ac71ebdc6460"
 dependencies = [
  "common-path",
  "derive-syn-parse",
@@ -2672,7 +2650,7 @@ dependencies = [
  "regex",
  "syn 2.0.50",
  "termcolor",
- "toml 0.7.4",
+ "toml 0.8.10",
  "walkdir",
 ]
 
@@ -2822,9 +2800,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encointer-balances-tx-payment"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "407d7faa8fd1d242602012e6b6d51a8edc99321ac5a20425efa64c7ec432f868"
+checksum = "4bab150ba5131d8e59e861d21b900d123cc55604160c118fb8b2293af5a40d3a"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2839,9 +2817,9 @@ dependencies = [
 
 [[package]]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb7b235a2ecbec5b913ee30c4372a9bb01c27cbca1368662ad9629df788a1be"
+checksum = "1086972f2ea49903c0f7051ec6ad0180e81df47c2b6699f1ff279afba749bba6"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2853,9 +2831,9 @@ dependencies = [
 
 [[package]]
 name = "encointer-ceremonies-assignment"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5e534e5d624f17a34ae5c6cf61ddbfd68b6a2d3900d855760ebb551f9d4fdd"
+checksum = "2ebd5dc49f5f6fb321b2e7315bf29e26f3d5f38a1e344f36213137e58fbd54ea"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -2891,7 +2869,7 @@ dependencies = [
  "hex-literal",
  "jsonrpsee",
  "log",
- "nix",
+ "nix 0.24.3",
  "pallet-encointer-bazaar-rpc",
  "pallet-encointer-bazaar-rpc-runtime-api",
  "pallet-encointer-ceremonies-rpc",
@@ -2949,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "encointer-kusama-runtime"
 version = "1.0.0"
-source = "git+https://github.com/encointer/runtimes.git?branch=ab/upgrade-polkadot-v1.6.0#437115e766f49b884aa1b5633dc83893b4a76fd1"
+source = "git+https://github.com/encointer/runtimes.git?branch=bkontur/bko-bump-to-1.7#817f944fbf3ffb9fe582e57aa897c3b2dcd4f616"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -2957,7 +2935,6 @@ dependencies = [
  "cumulus-pallet-xcm",
  "cumulus-pallet-xcmp-queue",
  "cumulus-primitives-core",
- "cumulus-primitives-timestamp",
  "cumulus-primitives-utility",
  "encointer-balances-tx-payment",
  "encointer-balances-tx-payment-rpc-runtime-api",
@@ -3021,14 +2998,13 @@ dependencies = [
  "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
- "system-parachains-constants",
 ]
 
 [[package]]
 name = "encointer-meetup-validation"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d27e886abe0f6fb716dcf7ee0b4e91ae624d96dce6e87c1d5bada9a4bf76d3"
+checksum = "aa8b43179179d387317d14bd69335aafb7663f49b77203950fe4deadf1439ed7"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -3040,11 +3016,11 @@ dependencies = [
 
 [[package]]
 name = "encointer-primitives"
-version = "5.0.0"
+version = "6.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db298e46082c2f9692d6e8d5365fde266ac09ed18dd1c72c109281acad1b2fb"
+checksum = "a4d3adcceca350eed739e9677fae4e1bea6c7ad526eee456ca30037cbcfe9b9a"
 dependencies = [
- "bs58 0.4.0",
+ "bs58 0.5.0",
  "crc",
  "ep-core",
  "frame-support",
@@ -3061,9 +3037,9 @@ dependencies = [
 
 [[package]]
 name = "encointer-rpc"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3c0dbaef44c825184b3031a01e9c3971f27a679c9d4ae86670e4a70ac80a2b"
+checksum = "f527e58caeeb9089d630ecaed587d44d07264aa72e2e7f893e57f5382539dc5d"
 dependencies = [
  "jsonrpsee",
  "jsonrpsee-core",
@@ -3135,9 +3111,9 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 
 [[package]]
 name = "ep-core"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84eac7952f21e9d5a28e5e3074a2ed1e7d26bbc08da770e43ec538ba2ee0d124"
+checksum = "0b20f3b698c54e106bcb0533055bf99d64ae9c53261e7ed24366d1ca729a1259"
 dependencies = [
  "array-bytes 6.1.0",
  "impl-serde",
@@ -3341,7 +3317,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "835c052cb0c08c1acf6ffd71c022172e18723949c8282f2b9f27efbc51e64534"
 dependencies = [
  "byteorder",
- "rand 0.8.5",
+ "rand",
  "rustc-hex",
  "static_assertions",
 ]
@@ -3404,9 +3380,9 @@ checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
 
 [[package]]
 name = "frame-benchmarking"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b16f7f853f64ec6fbc981b3e224cc3400752662da140ec62c160b5b859bab68"
+checksum = "4090659c6aaa3c4d5b6c6ec909b4b0a25dec10ad92aad5f729efa8d5bd4d806a"
 dependencies = [
  "frame-support",
  "frame-support-procedural",
@@ -3430,9 +3406,9 @@ dependencies = [
 
 [[package]]
 name = "frame-benchmarking-cli"
-version = "32.0.0"
+version = "33.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69fec078a73892cb5a7146671cf76e3abf23201fefe431a013399ac2e5b03b54"
+checksum = "efe02c96362e3c7308cdea7545859f767194a1f3f00928f0e1357f4b8a0b3b2c"
 dependencies = [
  "Inflector",
  "array-bytes 6.1.0",
@@ -3449,7 +3425,7 @@ dependencies = [
  "linked-hash-map",
  "log",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "rand_pcg",
  "sc-block-builder",
  "sc-cli",
@@ -3491,9 +3467,9 @@ dependencies = [
 
 [[package]]
 name = "frame-election-provider-support"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c596d956c4eedaffbe2fd6f75562e63e3e60001222bc6f8cc45fa77f3ea51791"
+checksum = "87da19ee99e6473cd057ead84337d20011fe5e299c6750e88e43b8b7963b8852"
 dependencies = [
  "frame-election-provider-solution-type",
  "frame-support",
@@ -3509,9 +3485,9 @@ dependencies = [
 
 [[package]]
 name = "frame-executive"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5247e367912fe95f813e96542921ab4edf671860fd557625b55f40155abf90"
+checksum = "09bff9574ee2dcc349f646e1d2faadf76afd688c2ea1bbac5e4a0e19a0c19c59"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -3540,9 +3516,9 @@ dependencies = [
 
 [[package]]
 name = "frame-remote-externalities"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ac8b505de5aa10e9c9548a3642fc708fc47fe3843b840992e6e6ab139f39d0"
+checksum = "360bfdb6821372164a65933d9a6d5998f38c722360b59b69d2bf78a87ef58b2a"
 dependencies = [
  "futures 0.3.28",
  "indicatif",
@@ -3551,6 +3527,7 @@ dependencies = [
  "parity-scale-codec",
  "serde",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-io",
  "sp-runtime",
  "sp-state-machine",
@@ -3562,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48b00bb3e82c465a435b08827e7abe5144345bc1a998848bdd7ce72fa203bb5"
+checksum = "a3b24824d29c43d0af94be3356bbf30338ededed649f6841d315a9ae067ce872"
 dependencies = [
  "aquamarine",
  "array-bytes 6.1.0",
@@ -3586,7 +3563,7 @@ dependencies = [
  "sp-api",
  "sp-arithmetic",
  "sp-core",
- "sp-core-hashing-proc-macro",
+ "sp-crypto-hashing-proc-macro",
  "sp-debug-derive",
  "sp-genesis-builder",
  "sp-inherents",
@@ -3604,9 +3581,9 @@ dependencies = [
 
 [[package]]
 name = "frame-support-procedural"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0be717139a0da9b31b559356db73f6ce48876d331e833ebdc32de3a9ad581e15"
+checksum = "3bf1d648c4007d421b9677b3c893256913498fff159dc2d85022cdd9cc432f3c"
 dependencies = [
  "Inflector",
  "cfg-expr",
@@ -3618,7 +3595,7 @@ dependencies = [
  "proc-macro-warning",
  "proc-macro2",
  "quote",
- "sp-core-hashing",
+ "sp-crypto-hashing",
  "syn 2.0.50",
 ]
 
@@ -3648,9 +3625,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "983b3215c8d97775b90dc1db88f858c46401682bd2fb8572bdd102ff8c2ca2a6"
+checksum = "5bc20a793c3cec0b11165c1075fe11a255b2491f3eef8230bb3073cb296e7383"
 dependencies = [
  "cfg-if",
  "docify",
@@ -3669,9 +3646,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system-benchmarking"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78a2fe203b01b596156b2514e0b890b4a628dbdb50925316e755aa623b6fe53"
+checksum = "ac47ee48fee3a0b49c9ab9ee68997dee3733776a355f780cf2858449cf495d69"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -3685,9 +3662,9 @@ dependencies = [
 
 [[package]]
 name = "frame-system-rpc-runtime-api"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d183819ea7df1d89acd61fe423ae6bec24a29d87db5c18182339a751c0837a"
+checksum = "4c1b20433c3c76b56ce905ed971631ec8c34fa64cf6c20e590afe46455fc0cc8"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -3695,9 +3672,9 @@ dependencies = [
 
 [[package]]
 name = "frame-try-runtime"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b3dab79d14d2e8f6329d7e5cb49f2bdb81b9ef3019b1c405d94defa137a353"
+checksum = "0eab87d07bc2f9a2160b818d1b7506c303b3b28b6a8a5f01dc5e2641390450b5"
 dependencies = [
  "frame-support",
  "parity-scale-codec",
@@ -3761,9 +3738,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -3771,9 +3748,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-executor"
@@ -3789,9 +3766,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-lite"
@@ -3810,9 +3787,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3832,15 +3809,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-timer"
@@ -3850,9 +3827,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.28"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures 0.1.31",
  "futures-channel",
@@ -3934,7 +3911,7 @@ version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea1015b5a70616b688dc230cfe50c8af89d972cb132d5a622814d29773b10b9"
 dependencies = [
- "rand 0.8.5",
+ "rand",
  "rand_core 0.6.4",
 ]
 
@@ -3974,19 +3951,6 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
-name = "globset"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "029d74589adefde59de1a0c4f4732695c32805624aec7b68d91503d4dba79afc"
-dependencies = [
- "aho-corasick 0.7.20",
- "bstr",
- "fnv",
- "log",
- "regex",
-]
 
 [[package]]
 name = "group"
@@ -4262,7 +4226,6 @@ dependencies = [
  "rustls-native-certs",
  "tokio",
  "tokio-rustls",
- "webpki-roots 0.23.1",
 ]
 
 [[package]]
@@ -4558,9 +4521,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee"
-version = "0.16.3"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "367a292944c07385839818bb71c8d76611138e2dedb0677d035b8da21d29c78b"
+checksum = "affdc52f7596ccb2d7645231fc6163bb314630c989b64998f3699a28b4d5d4dc"
 dependencies = [
  "jsonrpsee-core",
  "jsonrpsee-http-client",
@@ -4568,19 +4531,19 @@ dependencies = [
  "jsonrpsee-server",
  "jsonrpsee-types",
  "jsonrpsee-ws-client",
+ "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "jsonrpsee-client-transport"
-version = "0.16.3"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b3815d9f5d5de348e5f162b316dc9cdf4548305ebb15b4eb9328e66cf27d7a"
+checksum = "b5b005c793122d03217da09af68ba9383363caa950b90d3436106df8cabce935"
 dependencies = [
  "futures-util",
  "http",
  "jsonrpsee-core",
- "jsonrpsee-types",
  "pin-project",
  "rustls-native-certs",
  "soketto",
@@ -4589,28 +4552,25 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tracing",
- "webpki-roots 0.25.2",
+ "url",
 ]
 
 [[package]]
 name = "jsonrpsee-core"
-version = "0.16.3"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b5dde66c53d6dcdc8caea1874a45632ec0fcf5b437789f1e45766a1512ce803"
+checksum = "da2327ba8df2fdbd5e897e2b5ed25ce7f299d345b9736b6828814c3dbd1fd47b"
 dependencies = [
  "anyhow",
- "arrayvec 0.7.4",
  "async-lock",
  "async-trait",
  "beef",
- "futures-channel",
  "futures-timer",
  "futures-util",
- "globset",
  "hyper",
  "jsonrpsee-types",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -4622,28 +4582,29 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-http-client"
-version = "0.16.3"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e5f9fabdd5d79344728521bb65e3106b49ec405a78b66fbff073b72b389fa43"
+checksum = "5f80c17f62c7653ce767e3d7288b793dfec920f97067ceb189ebdd3570f2bc20"
 dependencies = [
  "async-trait",
  "hyper",
  "hyper-rustls",
  "jsonrpsee-core",
  "jsonrpsee-types",
- "rustc-hash",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tower",
  "tracing",
+ "url",
 ]
 
 [[package]]
 name = "jsonrpsee-proc-macros"
-version = "0.16.3"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44e8ab85614a08792b9bff6c8feee23be78c98d0182d4c622c05256ab553892a"
+checksum = "29110019693a4fa2dbda04876499d098fa16d70eba06b1e6e2b3f1b251419515"
 dependencies = [
  "heck",
  "proc-macro-crate 1.3.1",
@@ -4654,19 +4615,20 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-server"
-version = "0.16.3"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf4d945a6008c9b03db3354fb3c83ee02d2faa9f2e755ec1dfb69c3551b8f4ba"
+checksum = "82c39a00449c9ef3f50b84fc00fc4acba20ef8f559f07902244abf4c15c5ab9c"
 dependencies = [
- "futures-channel",
  "futures-util",
  "http",
  "hyper",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "route-recognizer",
  "serde",
  "serde_json",
  "soketto",
+ "thiserror",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -4676,9 +4638,9 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-types"
-version = "0.16.3"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "245ba8e5aa633dd1c1e4fae72bce06e71f42d34c14a2767c6b4d173b57bee5e5"
+checksum = "5be0be325642e850ed0bdff426674d2e66b2b7117c9be23a7caef68a2902b7d9"
 dependencies = [
  "anyhow",
  "beef",
@@ -4690,14 +4652,15 @@ dependencies = [
 
 [[package]]
 name = "jsonrpsee-ws-client"
-version = "0.16.3"
+version = "0.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1b3975ed5d73f456478681a417128597acd6a2487855fdb7b4a3d4d195bf5e"
+checksum = "bca9cb3933ccae417eb6b08c3448eb1cb46e39834e5b503e395e5e5bd08546c0"
 dependencies = [
  "http",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
+ "url",
 ]
 
 [[package]]
@@ -4727,21 +4690,6 @@ name = "keystream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33070833c9ee02266356de0c43f723152bd38bd96ddf52c82b3af10c9138b28"
-
-[[package]]
-name = "kusama-runtime-constants"
-version = "1.0.0"
-source = "git+https://github.com/encointer/runtimes.git?branch=ab/upgrade-polkadot-v1.6.0#437115e766f49b884aa1b5633dc83893b4a76fd1"
-dependencies = [
- "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "smallvec",
- "sp-core",
- "sp-runtime",
- "sp-weights",
- "staging-xcm-builder",
-]
 
 [[package]]
 name = "kvdb"
@@ -4898,7 +4846,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "pin-project",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "rw-stream-sink",
  "smallvec",
  "thiserror",
@@ -4954,7 +4902,7 @@ dependencies = [
  "multiaddr",
  "multihash 0.17.0",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "thiserror",
  "zeroize",
@@ -4979,7 +4927,7 @@ dependencies = [
  "libp2p-swarm",
  "log",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "smallvec",
  "thiserror",
@@ -5001,7 +4949,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm",
  "log",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "socket2 0.4.9",
  "tokio",
@@ -5037,7 +4985,7 @@ dependencies = [
  "log",
  "once_cell",
  "quick-protobuf",
- "rand 0.8.5",
+ "rand",
  "sha2 0.10.8",
  "snow",
  "static_assertions",
@@ -5059,7 +5007,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-swarm",
  "log",
- "rand 0.8.5",
+ "rand",
  "void",
 ]
 
@@ -5079,7 +5027,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "quinn-proto",
- "rand 0.8.5",
+ "rand",
  "rustls 0.20.8",
  "thiserror",
  "tokio",
@@ -5097,7 +5045,7 @@ dependencies = [
  "libp2p-core",
  "libp2p-identity",
  "libp2p-swarm",
- "rand 0.8.5",
+ "rand",
  "smallvec",
 ]
 
@@ -5116,7 +5064,7 @@ dependencies = [
  "libp2p-identity",
  "libp2p-swarm-derive",
  "log",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "tokio",
  "void",
@@ -5198,7 +5146,7 @@ dependencies = [
  "rw-stream-sink",
  "soketto",
  "url",
- "webpki-roots 0.22.6",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -5242,7 +5190,7 @@ dependencies = [
  "libsecp256k1-core",
  "libsecp256k1-gen-ecmult",
  "libsecp256k1-gen-genmult",
- "rand 0.8.5",
+ "rand",
  "serde",
  "sha2 0.9.9",
  "typenum",
@@ -5530,6 +5478,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "memmap2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe751422e4a8caa417e13c3ea66452215d7d63e19e604f4980461212f3ae1322"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5596,7 +5553,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69672161530e8aeca1d1400fbf3f1a1747ff60ea604265a4e906c2442df20532"
 dependencies = [
  "futures 0.3.28",
- "rand 0.8.5",
+ "rand",
  "thrift",
 ]
 
@@ -5652,7 +5609,7 @@ dependencies = [
  "lioness",
  "log",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "rand_distr",
  "subtle 2.4.1",
@@ -5662,9 +5619,9 @@ dependencies = [
 
 [[package]]
 name = "mmr-gadget"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d0ba6676a84f182dabd7c3ec2c92f0e882fe4e4179ddf76f02ac132e6eb0ab"
+checksum = "6f62cddc29c17965ab16a051a745520d41c28d8b4c2b6188aaf661db056d67c9"
 dependencies = [
  "futures 0.3.28",
  "log",
@@ -5682,11 +5639,10 @@ dependencies = [
 
 [[package]]
 name = "mmr-rpc"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19066d17147f6819ec25f5f6fc3b9fca2008ae745ac7fa2d55ddb1d207119eae"
+checksum = "2634b45039e064c343a0a77ed45e03ca027c84e1b250b2f3988af7cde9b7e79e"
 dependencies = [
- "anyhow",
  "jsonrpsee",
  "parity-scale-codec",
  "serde",
@@ -5906,7 +5862,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bddcd3bf5144b6392de80e04c347cd7fab2508f6df16a85fc496ecd5cec39bc"
 dependencies = [
- "rand 0.8.5",
+ "rand",
 ]
 
 [[package]]
@@ -5991,6 +5947,17 @@ dependencies = [
  "cfg-if",
  "libc",
  "memoffset 0.6.5",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -6158,9 +6125,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orchestra"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46d78e1deb2a8d54fc1f063a544130db4da31dfe4d5d3b493186424910222a76"
+checksum = "2356622ffdfe72362a45a1e5e87bb113b8327e596e39b91f11f0ef4395c8da79"
 dependencies = [
  "async-trait",
  "dyn-clonable",
@@ -6175,9 +6142,9 @@ dependencies = [
 
 [[package]]
 name = "orchestra-proc-macro"
-version = "0.3.3"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d035b1f968d91a826f2e34a9d6d02cb2af5aa7ca39ebd27922d850ab4b2dd2c6"
+checksum = "eedb646674596266dc9bb2b5c7eea7c36b32ecc7777eba0d510196972d72c4fd"
 dependencies = [
  "expander 2.0.0",
  "indexmap 2.1.0",
@@ -6199,10 +6166,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "pallet-asset-rate"
-version = "7.0.0"
+name = "pallet-asset-conversion"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6f4917bc6c9ed6864813bbb828e94c63e1878a21af89d25dd0ff7da742f53e"
+checksum = "4079f12db3cf98daa717337ab5b7e5ef15aa3bec3b497f501dc715d129b500da"
+dependencies = [
+ "frame-benchmarking",
+ "frame-support",
+ "frame-system",
+ "parity-scale-codec",
+ "scale-info",
+ "sp-api",
+ "sp-arithmetic",
+ "sp-core",
+ "sp-io",
+ "sp-runtime",
+ "sp-std",
+]
+
+[[package]]
+name = "pallet-asset-rate"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "571ce57fd846911041749832b46a8c2b01f0b79ffebcd7585e3973865607036d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6216,9 +6202,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-asset-tx-payment"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e967664d86219ca9f7d33504e8d914225cdb92e9e793d35edaab1fd2574f162f"
+checksum = "9ed783679921ad8b96807d683d320c314e305753b230d5c04dc713bab7aca64c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6235,9 +6221,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-assets"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aca79db2bc70c269170893604d8a56d0f32d52c75a23a3d887b6b4df132366b7"
+checksum = "46728a98a910af13f6a77033dd053456650773bb7adc71e0ba845bff7e31b33e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6252,9 +6238,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-aura"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10c6ecf016520a6883df14b2f1d469d98166377eba4b299af7b76eee0130e3a6"
+checksum = "a611bef3c8cf281e41a43f32a4153260bdc8b7b61b901e65c7a4442529224e11"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6270,9 +6256,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-authority-discovery"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9224b0a0bb4fa721d51f56947c73d4189710691b4cb40e7f7a8abf59795759a"
+checksum = "904f83f518b396c4fd1634fb675a36db0841f22420d3aa664bc154bee6035f57"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6287,9 +6273,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-authorship"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "817b0420f9c14bd9bfbaf9e2f769a7e8124ab4fe3da0d07c80485c0901947ab8"
+checksum = "3d83773e731a1760f99684b09961ed7b92acafe335f36f08ebb8313d3b9c72e2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6302,9 +6288,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-babe"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ba445228a941062d7c4d6295810a359df7757d6182c36ddb824f8c3bf350380"
+checksum = "d3f2020c52667a650d64e84a4bbb63388e25bc1c9bc872a8243d03bfcb285049"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6327,9 +6313,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-bags-list"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0d7b6922a6bed960591efb49da6637312c034337faf4c85d8b35f2e2c611a"
+checksum = "dd27bfa4bfa5751652842b81241c7eff3e68f2806d9dacc17b03d2cb20a39756"
 dependencies = [
  "aquamarine",
  "docify",
@@ -6350,10 +6336,11 @@ dependencies = [
 
 [[package]]
 name = "pallet-balances"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8406b5616e468d80972b6365f3cd8211d0dbf4d107b379fac85fddcfdf0b5562"
+checksum = "942007f4f7aace74b77009db1675e7ca98683a42dde5e2d85bba2a9f404d2e5a"
 dependencies = [
+ "docify",
  "frame-benchmarking",
  "frame-support",
  "frame-system",
@@ -6366,9 +6353,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03f71d32d9681e9d78102dad00377629cac24b4bf43f6371c0dc7e5b25981eb4"
+checksum = "4bedd80e9d8b196f31ea134efd271fdc1b8380ca3aa2d8af6ea8b5a0dc4fa460"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6387,9 +6374,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-beefy-mmr"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b8eaa5c053d9cbf20faa397f21b80b9b5bafbe428890b0171fd1bba16f52ce"
+checksum = "7d334f24d3c0c016d16aa87d069485847d622e8ebebace18ec5cf56609ca3a67"
 dependencies = [
  "array-bytes 6.1.0",
  "binary-merkle-tree",
@@ -6413,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-bounties"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5d421e3228bc4e8170d817d657aa87761b77ee4675a9e16328e1ca070cb4c41"
+checksum = "4765879e96676c13cdbed746d66fd59dcde1e9e65fda1f064fa2fffa3bc5d597"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6432,9 +6419,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-broker"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904983f117ff92ee24b251f2a883ff01b6f8e9063649877f3892ecbb516e3cbd"
+checksum = "fd8cfe04e8c3f9ca8342ac785f2b1aee6140e1809546fc6f3a99fad20a8dfbf9"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -6450,9 +6437,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-child-bounties"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb62c44d3ab8dcbf106b22acc138eaea6e51563d16a8d4a246303f2e20eeb9e5"
+checksum = "00fd06f2d719f5bb16ab3e836c6b053bbd92631ba694f8c2bf810013b2548167"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6470,9 +6457,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-collator-selection"
-version = "9.0.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4199122c135e161d2e2f4cbc9339c54a11ac4b11e0beb67e53b49a3c90d566b"
+checksum = "59b5ad46601c613396e92292a24c5b5d76e904c456ece9deb10913f6ea2e2999"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6481,7 +6468,7 @@ dependencies = [
  "pallet-authorship",
  "pallet-session",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "sp-runtime",
  "sp-staking",
@@ -6490,9 +6477,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-collective"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ed22cf9d91c120695063cfa95ae0ffabcadefdf2581657ddb5fd68555b3a2e0"
+checksum = "4c362a0b8f30895c15ecc7d8c24b0d94bb586c4b9bbd37ac8053b4629d9cc80b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6508,9 +6495,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-conviction-voting"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a189b5fb4a473edc7b2d52109fe10d0017b9b56f7c0324018b5970125db3ce3"
+checksum = "6aee3a8b6fcde893f862993f9d45eb0fcd492dde0967fd56ef78d79fc7b53dc0"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -6526,9 +6513,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-democracy"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b687c8a22b37f9b8444a29959f9cd0cf0be2f8efb8cd9bf91860d5dbafdab8b3"
+checksum = "aa781d632063087bcd3ff46eb1a668f15647ab116f1c8a7c573b7168f62d72c3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6545,9 +6532,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-election-provider-multi-phase"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc5e1f80bb4ce08b27f5a8a733d5c2d72d083a7d48afa4bdbb1ef3594a31e353"
+checksum = "b54d1d3fe9ae61a144d581147e699b7c3009169de0019a0f87cca0bed82681e7"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6556,7 +6543,7 @@ dependencies = [
  "log",
  "pallet-election-provider-support-benchmarking",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "sp-arithmetic",
  "sp-core",
@@ -6564,14 +6551,14 @@ dependencies = [
  "sp-npos-elections",
  "sp-runtime",
  "sp-std",
- "strum",
+ "strum 0.24.1",
 ]
 
 [[package]]
 name = "pallet-election-provider-support-benchmarking"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "193a8592c5fd534d56d07b2abe14e830d23947fb66f31867083e4f3ef80c8caa"
+checksum = "46ec87816a1e32a1ab6deececa99e21e6684b111efe87b11b8298328dbbefd01"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -6584,9 +6571,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-elections-phragmen"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dd2f70c57cbb3dcde39f141721dd34a8c852e0caaf61ae6b0bbd23138b6e1d3"
+checksum = "10cb0158cc7461fda5db04c5791d0df34635bec37181763aca449bade677d12d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6604,9 +6591,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-balances"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3abd8385b727858b9eac996991bb6bc2967ee51a5f1bdfd178455f073b1985c5"
+checksum = "d3e315674885628d9255be6ef76d3a50ef5dbaeaa377955d683754d5b6552a49"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -6624,9 +6611,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59c2f8fd0131a9e1c997e9f634c04e40af131a1c62c75ecd22d4f2fe25d6d1c0"
+checksum = "f9ef596e3cd3ef64c238452dbed148a6f021a1861ad9917183099b9ed59c2e55"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -6642,9 +6629,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f5c3902312aa07bb6e79db3aae3ec9890845e5d74368fbdfc779e6468901cb6"
+checksum = "3c4d18ee1163ab7c4d42f75d0347295809029c034bfec64545decd6b34cb5c5c"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -6663,9 +6650,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ca4fe43766549ed1261113039bbe44bc4b429fdd32db2848213e1918587134d"
+checksum = "ef7ad75291b1b151855c615a5cf4036f1468e22d635585f412d10e0453a94948"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -6676,9 +6663,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4638e64ecc2823182d42fb3e26f280c4f5c7c15a03e76de5a4471509268ef7e"
+checksum = "91d55a3cd08fdce58f6a92b373decc3709e5908f490a6e2e59aee7036776a64b"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-meetup-validation",
@@ -6702,9 +6689,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f4aa4c1afd27a6341d6e46c34acccd15c000c0a43376875c9d6734eab4ee5e"
+checksum = "9cf43efe76294b07e3157f4a8fabc65002c12a606c0626c922c5f389eb524108"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -6723,9 +6710,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9649454f58e1ce8019d33b733ef82098d8830d3e629d13a73e25013246e59ce2"
+checksum = "6a7655dd964c160eef8af3cc90a8acb235a4695530ff8e81df5176fd34107b84"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -6736,9 +6723,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07f8f9108f2527999c88a935e3e8a4dff693dc41fe03ae537e0654f06d1e76b"
+checksum = "4163b2b572515e0424d80deef6582e0b8663f75de2058394700ff0a1f7f5dd2f"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -6756,9 +6743,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities-rpc"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61da6038a8ee3ba5e5b820dd23d1c266c9d764244d90218b9506b9894d46c7e4"
+checksum = "603c12e535de2f9616f4f3c5cf2d1baa96a68dca06fb90955674b10a08288f86"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -6778,9 +6765,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49b6fc07a3baa660dd2522b00c8ca9959fd56145852c84700c83472c0328c061"
+checksum = "fc071c9227da132fe57ad496e615695ebcd6a892cc5d2a66d79eb4c3fac5902a"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -6790,9 +6777,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-faucet"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f315745473e6572629cf27cf41f29994b945116b516b2fb6503ab7bb784f05"
+checksum = "86e8faead921402e8ebd73272054a0974af2526e30e74bfb43fccb077aa93149"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -6812,9 +6799,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-reputation-commitments"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f89a194a51ec7326ac10908ea4a8840270a9bc0c3a12ae80cea46995f49c73d"
+checksum = "5777f365c18c93579880107b08299e77c85254076501130891a71b9be018690a"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -6835,9 +6822,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-scheduler"
-version = "5.0.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5804270f9ad33a67317bd52be71eca756d7307026ba399b096e1f3e330be4c"
+checksum = "26dc40684ab501ad233e5e6da4215a546392b503837a004d97153c482aaa561c"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -6854,9 +6841,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-fast-unstake"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6e0b51b82075b046792cdde2d4a2f6c9301f3deba44c26d30ab152060b9028"
+checksum = "2222607a0dba10a9d57cab5360a6549b5fda925181c3c7af481246c0964998df"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -6874,9 +6861,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-grandpa"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "935e91fa8936381aff2b88d8a7dad38ac30a1c8d2310340d73ce1c07b5ae72ce"
+checksum = "a5b20be8592eed7ebca2ee661fc43450088552ebe0bd483d7b101cf5968ab12d"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6898,9 +6885,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-identity"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3259bb87d50529027fa40267c3662dc80c683f253f121f391c032b019c88fcb"
+checksum = "e9e1cae19e30e7dc822c419988b30bb1318d79a8d5da92733822d0e84fe760ca"
 dependencies = [
  "enumflags2",
  "frame-benchmarking",
@@ -6916,9 +6903,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-im-online"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4be3f0165158828e4e77fae106a93bc1f48cc751755bdb012edb3ac0ef1d246"
+checksum = "598ea5c87351edc953d1f455f32ff456cf2f1daf7bbada1f1e03be8e384852ab"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6937,9 +6924,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-indices"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ead239524e40e55d172f024ff6795998068a2ba1c0950e74c4db7f347cfa91e"
+checksum = "2e880ebdb429ca76fb400b1b361ed7fce018a5ea2fc2da4764de5156fffdfa73"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6955,9 +6942,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-insecure-randomness-collective-flip"
-version = "16.0.0"
+version = "17.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3812708354757694bf127a89ab043ce80b2016a3b4d1eda2f762fbc4da9904"
+checksum = "d2d1abf59195719d739c65178f65f7fda6ddd0eaacd8e2273ca44f3a9b86d27a"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -6970,9 +6957,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-membership"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2dfdff5a7e5b21355b34245312ba2ea687444d9003960e7b876e1df518dab"
+checksum = "ad901cdf3de23daf23ff8b092ab318b13faebfc1aa4d84263f2fdc84feaf3e9b"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -6988,9 +6975,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-message-queue"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab6302efb264a65fd175f3082b72004df125f646a3c68b72fd08e657a468c0d6"
+checksum = "9ccb23dee70b184a214d729db550117a0965a69107d466d35181d60a6feede38"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -7009,9 +6996,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-mmr"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba6565b91d1d585047648793feece7c2c70080b37e1f55ab3a4fb50b4c1bec86"
+checksum = "a6f1f23a70764dad2b4094d8be12ebbb82df210f2e80dd36fa941a5ac191c6cd"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7028,9 +7015,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-multisig"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbcdea9d3d7963aab57078a5bd6f3596186bfcf181d666db6ea2bfdc0184ec"
+checksum = "176f6a5c170185f892a047c0ae189bc52eb390f2c0b94d4261ed0ebc7f82a548"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7045,9 +7032,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nis"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c541b2785051ebe1ae378be4b086055fbb8b13ee18fd949dfcf68dbd1c3325"
+checksum = "32a64a0e80dec2c60d5962dd249061a47dc4356db440f26cdec50b8acaded1d3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7062,9 +7049,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools"
-version = "25.0.3"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5989ca1100694371c9951118d58e84e93b60c1919006e9d4ad0f7537952c388"
+checksum = "0f14519c1c613d2f8c95c27015864c11a37969a23deeba9f6dbaff4276e1b81c"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7082,9 +7069,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-benchmarking"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d01847415cd33a92c65e8d13cb0041a32b2f2523c84d9d944287ae5c0d920c82"
+checksum = "18a1eba3078e2492cad15e4695f90eb3fc570386d9f71f8b81f709c7123fc6b5"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7103,9 +7090,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-nomination-pools-runtime-api"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64b17d862b833ca07a375646ecc80e164e5618c3aed4e5631816aa7288bf9b1"
+checksum = "bc5b35e6c471a669437b987ff02e11e2283412c9ebaeec5334dec3f73bcea652"
 dependencies = [
  "pallet-nomination-pools",
  "parity-scale-codec",
@@ -7115,9 +7102,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de7b17230f58ff6b1ec2a70b3c639c49f585841dacf63f30c78db6387a833e0b"
+checksum = "60b5bcfdc4f6032d7570929094fd459de12d840c440c395fb4d365d679e13eda"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7133,9 +7120,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-offences-benchmarking"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "060483993358293d041e5173635082c68c7783a800c0874e8df87c324232f0d1"
+checksum = "bbc33e3086c19235cb903cbbbde1bc1c4f428519ad4c23446dc84c75d0061582"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7158,9 +7145,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-preimage"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce688c68f117b1916a844579aa5a945d786059b119a1cc80ace370afd1e50da4"
+checksum = "7344a30c304771beb90aec34604100185e47cdc0366e268ad18922de602a0c7e"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7176,9 +7163,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-proxy"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3162924576a70509136eb4d8513497fb640a8b3ea753883fe29bd454c511485"
+checksum = "f7aa31a0b91e8060b808c3e3407e4578a5e94503b174b9e99769147b24fb2c56"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7192,13 +7179,14 @@ dependencies = [
 
 [[package]]
 name = "pallet-ranked-collective"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86c6d11592a6ba9039bd3486dba15f0cb045889b2746f4619f5ec78188fdd151"
+checksum = "3733dbfc44d8f5e1a08287a9064e5794e9d0e92b1bd68cdad2e22202b1964528"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
  "frame-system",
+ "impl-trait-for-tuples",
  "log",
  "parity-scale-codec",
  "scale-info",
@@ -7211,9 +7199,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-recovery"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8649310b8f00e3b2983331cdb7173d1e66e5eeb3a3d21479e7a65386244f883"
+checksum = "797b554ddc87082c18223440d61a81cf35ccab6573321ce473a099e7a709a760"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7227,9 +7215,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-referenda"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c6645c0c09ff8484c6c7ac1546d908202ed555b18169ea956955e4e2d77b210"
+checksum = "da850889e7101b63cadb980b7f39df67feb6d63bc6092769b9b708e9eb596db1"
 dependencies = [
  "assert_matches",
  "frame-benchmarking",
@@ -7247,9 +7235,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-root-testing"
-version = "4.0.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7bd13ad045bda70f0d2023333d36620bd7b48172646274572332dc9f62fd3c8"
+checksum = "59171cbf2b823c13685b1b80dd3e1e84425680ff4e006d8016f8c14d2ec44974"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7263,9 +7251,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-scheduler"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc26a27b77170c18261af7be04a6569e3d0d58788255b9f283ccd089aac37887"
+checksum = "45e2a4ebe6a5f98b14a26deed8d7a1ea28bb2c2d3ad4d6dc129a725523a2042d"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7282,9 +7270,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-session"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23ca2bfcffb5194de952050557bdd1fe9bce18b2bc81e8f8c01c8a3c3c3e5d8"
+checksum = "7412ac59247b300feee53709f7009a23d1c6f8c70528599f48f44e102d896d03"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7305,9 +7293,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-session-benchmarking"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc660786028d46e03fb0a419d6a15df3fa556db7ce74efebf5a35037b32b4bc4"
+checksum = "b9c2731415381020db1e78db8b40207f8423a16099e78f2fde599cbcb57ea8db"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7315,7 +7303,7 @@ dependencies = [
  "pallet-session",
  "pallet-staking",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "sp-runtime",
  "sp-session",
  "sp-std",
@@ -7323,9 +7311,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-society"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c19c1f5a410c0b03dc1e3245ffc0269e6c9085e6f6a64ee023f7515b6f8d9b"
+checksum = "dba64f96619c25ae7a0b41f4a5111c2d3102e8b8c6cbce80ece6955e825f9de2"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7342,9 +7330,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8883bbca2bd6ee41f81382418372ce44fd771ac53591ce9be4018ea43f8c5eda"
+checksum = "3a94127295cf027a26e933ea6788b0824e9fedd90740013673e2d36b5d707efe"
 dependencies = [
  "frame-benchmarking",
  "frame-election-provider-support",
@@ -7378,9 +7366,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-reward-fn"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e23336e4da87101633f95f9932946564c926ca7f87499654b38923b1579c605e"
+checksum = "505d45e08bad052f55fb51f00a6b6244d23ee46ffdc8091f6cddf4e3a880319d"
 dependencies = [
  "log",
  "sp-arithmetic",
@@ -7388,9 +7376,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-staking-runtime-api"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27156b772eccb539cb1a1ea1b1b6e98d9c6589e18b913a30f67913fcf67fe7e"
+checksum = "237d7b5a10cb6cba727c3e957fb241776302aa3cce589e6759ba53f50129c1a5"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -7399,9 +7387,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-state-trie-migration"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a48713905a318b0307e523fd3d3ca4b197ce74b2520203ded0d02e8a6c6bbd7"
+checksum = "d76e52dedc146b7a9c3b7c5a6ff4c4c442a8ab8cc58ec30e90e1e98cdc51ad34"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7417,9 +7405,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-sudo"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053dae9119d2d828af80e8ac98f497dc27155d6b5d42264dab8fae40f2314c41"
+checksum = "b6d02f7855d411913e77e57126f4a8b8a32d90d9bf47d0b747e367a1301729c3"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7434,9 +7422,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-timestamp"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688b89bdd377609b592bd094b304ebca33f4767fe72935465e2fd7db0e797968"
+checksum = "c1b8810ddfb254c7fb8cd7698229cce513d309a43ff117b38798dae6120f477b"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7455,9 +7443,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-tips"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "facf64cab7f7a4762c57e5827597b2ca073755de4c9716444cf0847db34836df"
+checksum = "8ca4b9921c9e9b59e8eeb64677ba6ec49743ef5fe98e0b63f77411b2b9f6cc99"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7475,9 +7463,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18b4ca7a1af9b1f091900a354a96319c7614d7a32106ba86cb7f0b6f90239065"
+checksum = "39f690f5c287ad34b28ca951ef7fae80b08cc9218d970723b7a70e4d29396872"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -7492,9 +7480,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1486d58f38892df779a7812f28ff962d0b0632b955ea3c348f605caa01ba6d"
+checksum = "08ef209d2d5d077e325bf49b024fd2eff109a5c2ca0d84ce0d50a65839e6b026"
 dependencies = [
  "jsonrpsee",
  "pallet-transaction-payment-rpc-runtime-api",
@@ -7509,9 +7497,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-transaction-payment-rpc-runtime-api"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acdfd7c882439b8198c99ece57b5bf785965545a6fa6d0bb7b56b264df1e437a"
+checksum = "c78bcba80c7c61712b98a6b5640975ebd25ceb688c18e975af78a0fac81785b0"
 dependencies = [
  "pallet-transaction-payment",
  "parity-scale-codec",
@@ -7522,9 +7510,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-treasury"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75cb7498228e1a150fa09ce64acafe7105ff39b75dae1c266ba58b7e3eb225e"
+checksum = "1605eb5083a2cd172544f33c6e59eca2e23ac49f02f13d1562b1b8a409df9c60"
 dependencies = [
  "docify",
  "frame-benchmarking",
@@ -7542,9 +7530,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-utility"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384c1d740c019410f6b40586cc387726c2e3c417c0e3e6f7e4774cd46bc6c1d0"
+checksum = "954f15b98c3fdebb763bb5cea4ec6803fd180d540ec5b07a9fcb2c118251d52c"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7559,9 +7547,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-vesting"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f3ac517a10c14beee86a737b9ea5d592af9ab21cc5354474bc5f7019210358"
+checksum = "4525f3038cdf078fea39d913c563ca626f09a615e7724f0c9eac97743c75ff44"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7575,9 +7563,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-whitelist"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de259e3329422bf3eb10b7e966f4b1c5caadcb29cd2d45af3a000cb2d184e60d"
+checksum = "da0ad4ce05688bdddcdb682cbed2f3edff0ee5349f0b745ebacc27d179582432"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7591,9 +7579,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cee3520e03ac679125e8dcaa00ce4afeeb106a9623e79b5acf970d72af7f5d02"
+checksum = "2b0bade2eb6ce40af35a5af150692b4e150638f7f68c15735ab9cdf79650d68e"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -7615,9 +7603,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm-benchmarks"
-version = "7.0.3"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "890bbad7a5752c8d4c3681457bac4e87fafc79cd9dd5b1a94e6f237f93a795a3"
+checksum = "3c10e1c92086ce2069a3d2387d9431f48660b6ec92054c4d0a4e30a9f54e7ad3"
 dependencies = [
  "frame-benchmarking",
  "frame-support",
@@ -7635,16 +7623,15 @@ dependencies = [
 
 [[package]]
 name = "parachains-common"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ceadd4f51620023871ece5eeda64734acd17d84d49b45473d335e900a012fdde"
+checksum = "d34aa00981a24a2b772afaa49e258f9bcd6bb372db060a05614becc1c74d4456"
 dependencies = [
  "cumulus-primitives-core",
  "cumulus-primitives-utility",
  "frame-support",
  "frame-system",
  "log",
- "num-traits",
  "pallet-asset-tx-payment",
  "pallet-assets",
  "pallet-authorship",
@@ -7653,11 +7640,8 @@ dependencies = [
  "pallet-message-queue",
  "pallet-xcm",
  "parity-scale-codec",
- "polkadot-core-primitives",
  "polkadot-primitives",
- "rococo-runtime-constants",
  "scale-info",
- "smallvec",
  "sp-consensus-aura",
  "sp-core",
  "sp-io",
@@ -7665,10 +7649,8 @@ dependencies = [
  "sp-std",
  "staging-parachain-info",
  "staging-xcm",
- "staging-xcm-builder",
  "staging-xcm-executor",
  "substrate-wasm-builder",
- "westend-runtime-constants",
 ]
 
 [[package]]
@@ -7684,9 +7666,9 @@ dependencies = [
  "libc",
  "log",
  "lz4",
- "memmap2",
+ "memmap2 0.5.10",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "siphasher",
  "snap",
  "winapi",
@@ -7963,9 +7945,9 @@ checksum = "e3d7ddaed09e0eb771a79ab0fd64609ba0afb0a8366421957936ad14cbd13630"
 
 [[package]]
 name = "polkadot-approval-distribution"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98fd276eccca3ada04cb274f4b8c51f669087d8b334c775f1231a9194d5260d0"
+checksum = "8cdfa52beecc446ccf733dede1a0089e6396d3df13401004d27c0ce2530816bc"
 dependencies = [
  "bitvec",
  "futures 0.3.28",
@@ -7978,15 +7960,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand 0.8.5",
+ "rand",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-bitfield-distribution"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51c43e54e0cc47dfb4f7c3917a774ccc796524087515b212d9fe109bde71846e"
+checksum = "80ffc856dfbdb31178625760824ae320ddb7dd5694b217f489bd2832b8de15a5"
 dependencies = [
  "always-assert",
  "futures 0.3.28",
@@ -7995,15 +7977,15 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand 0.8.5",
+ "rand",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-availability-distribution"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "121ded25722b8505335b05a77f1def84278802ed3f4774c7fe6ab7c961affe06"
+checksum = "c9d05c26cc8d6fa0f5f432d9de880f20ad0d24ca51a618834ea6612d1bd96ab1"
 dependencies = [
  "derive_more",
  "fatality",
@@ -8015,7 +7997,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand 0.8.5",
+ "rand",
  "schnellru",
  "sp-core",
  "sp-keystore",
@@ -8025,9 +8007,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-availability-recovery"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3902495dbba25e7526168c8f88b26cc0dbb96cfe10813238a650c67b34bf9f31"
+checksum = "4d77e0b979f43861ab4c78c216c2729644bb12812f9bc859858bd3b8fc56b4d6"
 dependencies = [
  "async-trait",
  "fatality",
@@ -8039,7 +8021,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand 0.8.5",
+ "rand",
  "sc-network",
  "schnellru",
  "thiserror",
@@ -8049,9 +8031,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-cli"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93cafe0d136732ad69bce9cd82a34a7b1ff0cd2268d84309aeb673622d40a013"
+checksum = "ef362c44280e3883a39ca452acc4a4fb61a18250d634d68578b22df7edd8290c"
 dependencies = [
  "cfg-if",
  "clap",
@@ -8078,9 +8060,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-collator-protocol"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70007b246c3679ee43f11123bda6d715f659f7b6d4134d0fcbe8980e049386b"
+checksum = "507391f1be9f9b9a8fbf28ca13b0ab3f04947a54a1115d423d115aacf8889bf4"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8101,9 +8083,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-core-primitives"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda2b0f0c580c38f12445a4af10e0a23acf48381b2a95653e0be48ba787e10e5"
+checksum = "b6a08e4e014c853b252ecbbe3ccd67b2d33d78e46988d309b8cccf4ac06e25ef"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -8114,15 +8096,15 @@ dependencies = [
 
 [[package]]
 name = "polkadot-dispute-distribution"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a9b173e02d1f600a422269b3b5a1db203d39f436f7db7d7e41ef6dda6f42e0"
+checksum = "ae32e83ef6bc0ec2874c76c19dff8f3795832ccc27f0abc587a7137994c42d26"
 dependencies = [
  "derive_more",
  "fatality",
  "futures 0.3.28",
  "futures-timer",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "parity-scale-codec",
  "polkadot-erasure-coding",
  "polkadot-node-network-protocol",
@@ -8140,9 +8122,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-erasure-coding"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff8347b3528fe94e47ec1b818b06bf821010a5f180d0ac5c89138da0d382debc"
+checksum = "1b10514ace3272d38b602e1795a5a340b265285c4af875473d682a5c9d6c831c"
 dependencies = [
  "parity-scale-codec",
  "polkadot-node-primitives",
@@ -8155,9 +8137,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-gossip-support"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4de739371a4b5f036848de5c7185dfee88587016d2bb32af07f38fb909b80d8"
+checksum = "01f05f7f60022d4beb30414f1f7c7e4ae728fea02086a4a0f8ff0a73e73ea4aa"
 dependencies = [
  "futures 0.3.28",
  "futures-timer",
@@ -8165,21 +8147,22 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "sc-network",
  "sc-network-common",
  "sp-application-crypto",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-keystore",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-network-bridge"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4598c9d00dbc017c0f01e82a7c0740805cc500c3b8946ad0b7945ab4d68dd7ee"
+checksum = "049ec1298ac6e96bcf4d980cd5864aceeee73b3298ab5d6dd7a3193d47578abc"
 dependencies = [
  "always-assert",
  "async-trait",
@@ -8201,9 +8184,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-collation-generation"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba987629ab789f529426d6187dbafaa8209f5ee479c645184e4c1e33a59e2135"
+checksum = "6f1211ab8b154c2e2b4b89c64f57f96056c881e4fcfa2ce29b6e5cbc978e74f1"
 dependencies = [
  "futures 0.3.28",
  "parity-scale-codec",
@@ -8220,9 +8203,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-approval-voting"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5910fa99def47accbb4505bef91f74614f62347bc0c53c11296d5ce70d8e255"
+checksum = "c61a17b7e4edd3b73afbe0c6e8b5369bf3b721361a232baf11fb1698077067a4"
 dependencies = [
  "bitvec",
  "derive_more",
@@ -8238,7 +8221,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-overseer",
  "polkadot-primitives",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sc-keystore",
@@ -8254,9 +8237,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-av-store"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ab1583533dc82a719607323432c013e01c2a8c971eb7e7703ff5eadd762f4e3"
+checksum = "84b334f06423ff701e4b807d6832741ec24e0e97ebc13b560fc99bc0652926c0"
 dependencies = [
  "bitvec",
  "futures 0.3.28",
@@ -8277,9 +8260,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-backing"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b5468fa618ccbeb4611b073d2c28b9440b51f4012e69c117e43192f9de8b17"
+checksum = "f07f8840f3f2f0bee6264c18ce471c99c925f9afb65952e1d584b6d773cf4115"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8290,6 +8273,7 @@ dependencies = [
  "polkadot-node-subsystem-util",
  "polkadot-primitives",
  "polkadot-statement-table",
+ "schnellru",
  "sp-keystore",
  "thiserror",
  "tracing-gum",
@@ -8297,9 +8281,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-bitfield-signing"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4975e2ecc81d34605748781e9449a7b7ff956c385b46496005257a1a7dd56f0d"
+checksum = "0687006f843d6da8687eb24da735a04cbdcf4c3a98d82055b9b3a9047537e17e"
 dependencies = [
  "futures 0.3.28",
  "polkadot-node-subsystem",
@@ -8313,9 +8297,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-candidate-validation"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcfd720b86c1ddf6616cf083a2cb273147687521c1d13a7f3c991b1d5ae03444"
+checksum = "c3035acf9069801e980b91b5178591f8a7052b4409de13824db7a6c798b36b98"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -8335,9 +8319,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-api"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a9f00bd39f433a2e8281524529853a3be54970e799a451e2c14fc5b75cf226f"
+checksum = "c990b9ffdde6725fe79f55e3b7c4c32ce2134a06103708476fa595a4ac652e95"
 dependencies = [
  "futures 0.3.28",
  "polkadot-node-metrics",
@@ -8350,9 +8334,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-chain-selection"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea28475a96dfb6419432314d8021780e5c5b0f50a5525fd332e8b2a947a2deb5"
+checksum = "451965f3ace786d392c407872d61324765061b87027890b02ffd625554531f97"
 dependencies = [
  "futures 0.3.28",
  "futures-timer",
@@ -8368,9 +8352,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-dispute-coordinator"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad9cfb3e775dc4c611a79e294549fe4b244052ddaacf14133380e793c25a99f"
+checksum = "c13ea9d5b4aa43b5b1f718c3ec951adff0b0d74909cb1fe28206f5d88492247d"
 dependencies = [
  "fatality",
  "futures 0.3.28",
@@ -8388,9 +8372,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-parachains-inherent"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2535ef374a218b1e9d05b98a903edbdddf4eea47f9e137fcc09c8e1bc199dd"
+checksum = "6574c0bda4e10d722f761d4b8ab5d1708f0f963e5840370aa9cee8f559c90a23"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -8406,9 +8390,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-prospective-parachains"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15a8876cc0aa627190f1d41c01061a7acee9621703501d9a60118d35e81579f9"
+checksum = "160f80a11b9d2b8e36e510ea54ce5b06e77179c0c502f7e19e5a5809bc1523ee"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8424,9 +8408,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-provisioner"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25c88b17b93bf410a72bfb4543b1ae01bb0d33fd6cba9af1f0e74c4ef2b906ad"
+checksum = "b0d0a64371700537c3dc15b3956536e4541f093b7c38ac21737ea9fea3562a83"
 dependencies = [
  "bitvec",
  "fatality",
@@ -8442,9 +8426,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c80f2810b2eb843f3282b11e7ce1624866b6dd1ee6a95541b5882b5df3f36f25"
+checksum = "f3bbb1b5f4b966f21a0336e94c0a0222958d2f3cba451da1157af271d07f9748"
 dependencies = [
  "always-assert",
  "array-bytes 6.1.0",
@@ -8463,7 +8447,7 @@ dependencies = [
  "polkadot-node-subsystem",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
- "rand 0.8.5",
+ "rand",
  "slotmap",
  "sp-core",
  "sp-maybe-compressed-blob",
@@ -8476,9 +8460,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-checker"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14d8ddb21cb3ad1868967b116fbf289610880cb95313b2798762cdd8653d36b7"
+checksum = "94ab4a91e62a9f7e67cf400931578f2505417cc43a32ac29458163604f2b277b"
 dependencies = [
  "futures 0.3.28",
  "polkadot-node-primitives",
@@ -8493,15 +8477,16 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-pvf-common"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80bbf311b112a8552e89e5be55b0305d86328ba04528e47d3203cd27751405bc"
+checksum = "003981d3b63e4f527ef7f03cbe280e41ec649d9be365668887f0b107610640f4"
 dependencies = [
  "cfg-if",
  "cpu-time",
  "futures 0.3.28",
  "landlock",
  "libc",
+ "nix 0.27.1",
  "parity-scale-codec",
  "polkadot-parachain-primitives",
  "polkadot-primitives",
@@ -8510,6 +8495,7 @@ dependencies = [
  "sc-executor-wasmtime",
  "seccompiler",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-externalities",
  "sp-io",
  "sp-tracing",
@@ -8519,9 +8505,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-core-runtime-api"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17345f76b7ebcf2f1e1be5411a6420971ef60d69070f115e459b2f017f91bcb5"
+checksum = "6ba6ea6a03f297b7387fc59c41c3c32285803971cb27e81d7e9ca696824d6773"
 dependencies = [
  "futures 0.3.28",
  "polkadot-node-metrics",
@@ -8535,9 +8521,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-jaeger"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b099624af4597bac5d1617a3cab057785ee47e657de7ad078957bfa397d82c4"
+checksum = "f7d113b48e7b6126964c3a790b101d99e17fd3cb75a92e94d54587ce1340df21"
 dependencies = [
  "lazy_static",
  "log",
@@ -8554,9 +8540,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-metrics"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2b5b00a9646875f22ab45e61ede04f623a3fbbc03bae52263b3d558c964bc32"
+checksum = "aef2e2a934f0d0d606fcfc53fc26f4cacd8b9f18fb2118829203fa813af2cdae"
 dependencies = [
  "bs58 0.5.0",
  "futures 0.3.28",
@@ -8574,9 +8560,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-network-protocol"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e420ba9220abaa468a393ff2834b7c2b4d7d87b6d903d9046dfd682c97d35d4c"
+checksum = "07f9e67b0f25d695947a15b6fe8ee6f8e83f3dfcbca124a13281c0edd0dc4703"
 dependencies = [
  "async-channel",
  "async-trait",
@@ -8589,19 +8575,19 @@ dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-primitives",
  "polkadot-primitives",
- "rand 0.8.5",
+ "rand",
  "sc-authority-discovery",
  "sc-network",
- "strum",
+ "strum 0.24.1",
  "thiserror",
  "tracing-gum",
 ]
 
 [[package]]
 name = "polkadot-node-primitives"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "366d18f1498426975c610246063149ad84788eb1e924cab6ee44a4d8958ecf61"
+checksum = "375744eee7a53576387e14856e1c65be8ecef8b449567bb2cff85706266c8912"
 dependencies = [
  "bitvec",
  "bounded-vec",
@@ -8623,9 +8609,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831cf07bf6588d7d8ab872f8f214b4b24b2c4243faf8028534f8a11a3f03c466"
+checksum = "24d6c226cdbcd48ab1e506d8512f0fb01839f9a72eec2fc0cf7771f6d3352171"
 dependencies = [
  "polkadot-node-jaeger",
  "polkadot-node-subsystem-types",
@@ -8634,9 +8620,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-types"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd132afdfcdf2e30f7924c9561bbc1208b0838ab9c2275bf0ef32525f63b8bd0"
+checksum = "1404525da0ab9d44bac1041449bf0c5576240f9031b305dc41654567e98b6021"
 dependencies = [
  "async-trait",
  "bitvec",
@@ -8663,9 +8649,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-node-subsystem-util"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32c2f2027689777bd61681d769ed5ec726144905c4e3cb16c5f8a4edb55250a"
+checksum = "65a7d101f28bf718d15f01a060ed8cf7a7e2d8d5705c494b49ece696cada0adf"
 dependencies = [
  "async-trait",
  "derive_more",
@@ -8687,7 +8673,7 @@ dependencies = [
  "polkadot-overseer",
  "polkadot-primitives",
  "prioritized-metered-channel",
- "rand 0.8.5",
+ "rand",
  "sc-client-api",
  "schnellru",
  "sp-application-crypto",
@@ -8699,9 +8685,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-overseer"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa0b71f50f0be1959bcb10a46105ca66b9c6868d549385a247750e5b7a45c77"
+checksum = "bd5ed988deffeddf440473586f62efc5dd498f6016e6650881db09dd60b3b24f"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -8722,9 +8708,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-parachain-primitives"
-version = "6.0.0"
+version = "7.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b37c55955147479e7b2f3c2e5385db4846ac3e3b997cd4a4ad52344524b5447"
+checksum = "248ab090959a92e61493277e33b7e85104280a4beb4cb0815137d3c8c50a07f4"
 dependencies = [
  "bounded-collections",
  "derive_more",
@@ -8740,12 +8726,13 @@ dependencies = [
 
 [[package]]
 name = "polkadot-primitives"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aefd230a654f5b2aee18ebbd9c081835def0e1898ee6c018501dd77c18f5929"
+checksum = "e0d5f9930210cab0233d81204415c9ef4a8889cdf3e60de1435250481a2773ca"
 dependencies = [
  "bitvec",
  "hex-literal",
+ "log",
  "parity-scale-codec",
  "polkadot-core-primitives",
  "polkadot-parachain-primitives",
@@ -8767,9 +8754,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-rpc"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382eada9005c73375778e1dca58116e0660431cf90989fe0dde54ebe1f621a1e"
+checksum = "bb4747cb8faa532e8446b38b74266fd626d6b660fe6b00776dd6c4543cc0457f"
 dependencies = [
  "jsonrpsee",
  "mmr-rpc",
@@ -8801,9 +8788,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-common"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4641a850b7415a42e56bd262aba243ed77a9280cb2b825a427c425bdc8961d70"
+checksum = "06afbb3bd10245ad1907242a98ddffc3c0c1e209738b8382bc5bcfc1f28c0429"
 dependencies = [
  "bitvec",
  "frame-benchmarking",
@@ -8828,7 +8815,6 @@ dependencies = [
  "pallet-transaction-payment",
  "pallet-treasury",
  "pallet-vesting",
- "pallet-xcm-benchmarks",
  "parity-scale-codec",
  "polkadot-primitives",
  "polkadot-runtime-parachains",
@@ -8853,25 +8839,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "polkadot-runtime-constants"
-version = "1.0.0"
-source = "git+https://github.com/encointer/runtimes.git?branch=ab/upgrade-polkadot-v1.6.0#437115e766f49b884aa1b5633dc83893b4a76fd1"
-dependencies = [
- "frame-support",
- "polkadot-primitives",
- "polkadot-runtime-common",
- "smallvec",
- "sp-core",
- "sp-runtime",
- "sp-weights",
- "staging-xcm-builder",
-]
-
-[[package]]
 name = "polkadot-runtime-metrics"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac3c6ee03f38556274b26049c51c5c7095abfd4ebfd11cd492918a4344f2851"
+checksum = "e3566c6fd0c21b5dd555309427c984cf506f875ee90f710acea295b478fecbe0"
 dependencies = [
  "bs58 0.5.0",
  "frame-benchmarking",
@@ -8883,9 +8854,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-runtime-parachains"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d253ef2952097398d98ed12729e47f9328bcd1baa92c3acc1524a4baca7d1ac"
+checksum = "9bcfd672be236fd1c38c702e7e99fe3f3e54df0ddb8127e542423221d1f50669"
 dependencies = [
  "bitflags 1.3.2",
  "bitvec",
@@ -8910,7 +8881,7 @@ dependencies = [
  "polkadot-parachain-primitives",
  "polkadot-primitives",
  "polkadot-runtime-metrics",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "rustc-hex",
  "scale-info",
@@ -8933,9 +8904,9 @@ dependencies = [
 
 [[package]]
 name = "polkadot-service"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75bf984471c2608905176b62726b3552bbfdc3e04ebdc7fe75e5179ff215588"
+checksum = "b2fd665185877bec296588c7cf1ec0ef75e0545050b5e1d42d94240a284149da"
 dependencies = [
  "async-trait",
  "frame-benchmarking",
@@ -9051,16 +9022,16 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-distribution"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82b48ff9204ea663ccccde78aefa8a524958aadff5c84a4f1fd773c291057d"
+checksum = "8ff6d16cbd994987f48a9f107f12e4c7fff26cdd71df6288e9521adc7cff3427"
 dependencies = [
  "arrayvec 0.7.4",
  "bitvec",
  "fatality",
  "futures 0.3.28",
  "futures-timer",
- "indexmap 1.9.3",
+ "indexmap 2.1.0",
  "parity-scale-codec",
  "polkadot-node-network-protocol",
  "polkadot-node-primitives",
@@ -9075,13 +9046,14 @@ dependencies = [
 
 [[package]]
 name = "polkadot-statement-table"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478dea03265eb2465010dae149616e4f28fe858e103671b1a96dc19e9e388c8f"
+checksum = "de5e010da3c6a65d8f263d0f825a04d995ffc8a37f886f674fcbbc73bf158d01"
 dependencies = [
  "parity-scale-codec",
  "polkadot-primitives",
  "sp-core",
+ "tracing-gum",
 ]
 
 [[package]]
@@ -9249,9 +9221,9 @@ dependencies = [
 
 [[package]]
 name = "prioritized-metered-channel"
-version = "0.5.1"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e99f0c89bd88f393aab44a4ab949351f7bc7e7e1179d11ecbfe50cbe4c47e342"
+checksum = "a172e6cc603231f2cf004232eabcecccc0da53ba576ab286ef7baa0cfc7927ad"
 dependencies = [
  "coarsetime",
  "crossbeam-queue",
@@ -9385,7 +9357,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.3",
 ]
 
 [[package]]
@@ -9402,7 +9384,7 @@ dependencies = [
  "multimap",
  "petgraph",
  "prettyplease 0.1.25",
- "prost",
+ "prost 0.11.9",
  "prost-types",
  "regex",
  "syn 1.0.109",
@@ -9424,12 +9406,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools 0.11.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.50",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
 ]
 
 [[package]]
@@ -9487,7 +9482,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67c10f662eee9c94ddd7135043e544f3c82fa839a1e7b865911331961b53186c"
 dependencies = [
  "bytes",
- "rand 0.8.5",
+ "rand",
  "ring 0.16.20",
  "rustc-hash",
  "rustls 0.20.8",
@@ -9512,19 +9507,6 @@ name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
-
-[[package]]
-name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
 
 [[package]]
 name = "rand"
@@ -9582,16 +9564,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "rand",
 ]
 
 [[package]]
@@ -9674,14 +9647,13 @@ dependencies = [
 
 [[package]]
 name = "reed-solomon-novelpoly"
-version = "1.0.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bd8f48b2066e9f69ab192797d66da804d1935bf22763204ed3675740cb0f221"
+checksum = "87413ebb313323d431e85d0afc5a68222aaed972843537cbfe5f061cf1b4bcab"
 dependencies = [
  "derive_more",
  "fs-err",
- "itertools 0.10.5",
- "static_init 0.5.2",
+ "static_init",
  "thiserror",
 ]
 
@@ -9723,7 +9695,7 @@ version = "1.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
 dependencies = [
- "aho-corasick 1.0.2",
+ "aho-corasick",
  "memchr",
  "regex-syntax 0.7.2",
 ]
@@ -9819,9 +9791,9 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e5ae118c3f3189a376703a4ca8569eb51ce1b121bc6b571c051b68c31e10a16"
+checksum = "d089e93be2b8b76dd0d4b794a6a995ca3a1d6cb0ea3dd1cd42462f048bcfc926"
 dependencies = [
  "binary-merkle-tree",
  "frame-benchmarking",
@@ -9916,9 +9888,9 @@ dependencies = [
 
 [[package]]
 name = "rococo-runtime-constants"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b5b507493a19b5061eb2860c394847261216c7ea7f8f62ba2cb02e55c27d611"
+checksum = "0b45c21ccb0f8777512a65510c106aeee4b59682944b9a5cb31cd7b8ed4ccb47"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -9930,6 +9902,12 @@ dependencies = [
  "staging-xcm",
  "staging-xcm-builder",
 ]
+
+[[package]]
+name = "route-recognizer"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afab94fb28594581f62d981211a9a4d53cc8130bbcbbb89a0440d9b8e81a7746"
 
 [[package]]
 name = "rpassword"
@@ -9952,7 +9930,7 @@ dependencies = [
  "log",
  "netlink-packet-route",
  "netlink-proto",
- "nix",
+ "nix 0.24.3",
  "thiserror",
  "tokio",
 ]
@@ -10073,7 +10051,7 @@ checksum = "446e14c5cda4f3f30fe71863c34ec70f5ac79d6087097ad0bb433e1be5edf04c"
 dependencies = [
  "log",
  "ring 0.17.3",
- "rustls-webpki 0.101.7",
+ "rustls-webpki",
  "sct",
 ]
 
@@ -10096,16 +10074,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d194b56d58803a43635bdc398cd17e383d6f71f9182b9a192c127ca42494a59b"
 dependencies = [
  "base64 0.21.2",
-]
-
-[[package]]
-name = "rustls-webpki"
-version = "0.100.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6a5fc258f1c1276dfe3016516945546e2d5383911efc0fc4f1cdc5df3a4ae3"
-dependencies = [
- "ring 0.16.20",
- "untrusted 0.7.1",
 ]
 
 [[package]]
@@ -10181,9 +10149,9 @@ dependencies = [
 
 [[package]]
 name = "sc-allocator"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43b05714bc70605d5f8983612d1643d875cd4782ef53a8720907a0eb75070cba"
+checksum = "357127c91373ed6d1ae582f6e3300ab5b13bcde43bbf270a891f44194ef48b70"
 dependencies = [
  "log",
  "sp-core",
@@ -10193,9 +10161,9 @@ dependencies = [
 
 [[package]]
 name = "sc-authority-discovery"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1c23040352415cdcc22203d3b18e56f3516e51865f106f8bbf7efa95b411a59"
+checksum = "7fb3c14cb8022844835a6f7209196b8c6544d389fe5d2972d8df2ae4ca75afbe"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -10206,9 +10174,9 @@ dependencies = [
  "multihash 0.18.1",
  "multihash-codetable",
  "parity-scale-codec",
- "prost",
+ "prost 0.12.3",
  "prost-build",
- "rand 0.8.5",
+ "rand",
  "sc-client-api",
  "sc-network",
  "sp-api",
@@ -10223,9 +10191,9 @@ dependencies = [
 
 [[package]]
 name = "sc-basic-authorship"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c016e38155386e23649a4a995ea67c55a1fe25a54c7cc7509954d454ee75eb3b"
+checksum = "724c3a6eee5f0829a1b79a15e12d63ed81b33281b14004a6331a8883b2fd8fd1"
 dependencies = [
  "futures 0.3.28",
  "futures-timer",
@@ -10246,9 +10214,9 @@ dependencies = [
 
 [[package]]
 name = "sc-block-builder"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656b85de8aad8dd758f2e5f250f300e4711f294f238c9299064fbd624cb263f7"
+checksum = "8e8b0640994965c6ff3afa13242d95a61611b83da21fd86ac2b1ebd03e241a02"
 dependencies = [
  "parity-scale-codec",
  "sp-api",
@@ -10262,14 +10230,14 @@ dependencies = [
 
 [[package]]
 name = "sc-chain-spec"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7f6a6926973e084fe9b23ffee9784cd41d84ea0627c605891542661bd9ff958"
+checksum = "0f73880050f8b04fed7f6301279ef3899df13a3891bd06156d56f9a1c50fefba"
 dependencies = [
  "array-bytes 6.1.0",
  "docify",
  "log",
- "memmap2",
+ "memmap2 0.9.4",
  "parity-scale-codec",
  "sc-chain-spec-derive",
  "sc-client-api",
@@ -10280,6 +10248,7 @@ dependencies = [
  "serde_json",
  "sp-blockchain",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-genesis-builder",
  "sp-io",
  "sp-runtime",
@@ -10300,9 +10269,9 @@ dependencies = [
 
 [[package]]
 name = "sc-cli"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9819b656041094ca4e97402be145c2bcf3f47d00d854708b25ecd3211eafcd62"
+checksum = "e8a284c10ea92b1fe789b9f0e5815d393f3a1e3bf6a4adaa884f24e36143b83b"
 dependencies = [
  "array-bytes 6.1.0",
  "bip39",
@@ -10315,7 +10284,7 @@ dependencies = [
  "log",
  "names",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "regex",
  "rpassword",
  "sc-client-api",
@@ -10342,9 +10311,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-api"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af05565a0f6467ebe0b430f3a44524fecee9e4aff621647ea5eab8833f775b6f"
+checksum = "3e914dfadaaf384d8869ae47f3ec783bf6a1ac24e7827f5fec2e0e649a450a91"
 dependencies = [
  "fnv",
  "futures 0.3.28",
@@ -10370,9 +10339,9 @@ dependencies = [
 
 [[package]]
 name = "sc-client-db"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db9fbd18eb275120fdf2e9558a5006a69022405abb9c260c91d218ddb05db39"
+checksum = "1f08c4f29e6d2b8915bab6435b8817fa39ef7708c04a7cf6226f803e133b017c"
 dependencies = [
  "hash-db",
  "kvdb",
@@ -10397,9 +10366,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0409758bb01f2e975b01c7cb2203aa27746e9796a483b18c57123e6e78fae5"
+checksum = "c8e1ac2c698b828073982b6f5b1a466fcc345a452983356af74254ade8e9987d"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -10423,9 +10392,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-aura"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc4ebc06768af3e5457a5780aa6dbebeefe27131e70d11b62cfc8136e41747a"
+checksum = "a16fd09794291795ad43ea1df7190083f9a47fc0a73e9b8ec0ae98fbe53a2b34"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -10453,9 +10422,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a7d698d9d2bde7e0b80e7ada57ede9255a6382da79d2ad9a4e9e70805c40e74"
+checksum = "82ec3dc31f8fd024684d1306488836680558b680a8ec38219e19f20854811f02"
 dependencies = [
  "async-trait",
  "fork-tree",
@@ -10480,6 +10449,7 @@ dependencies = [
  "sp-consensus-babe",
  "sp-consensus-slots",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-inherents",
  "sp-keystore",
  "sp-runtime",
@@ -10489,9 +10459,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-babe-rpc"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f55379d0ce6f87026f896f03bce33862b57f77a46fbb4fb7e974182d20d458"
+checksum = "bf2b3004672f9eea0d9af6c9b944fa3ef0bc72fd88cea9075cdf6dc96d1439ac"
 dependencies = [
  "futures 0.3.28",
  "jsonrpsee",
@@ -10512,9 +10482,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3664a3cddc718187e058f67d9075ef9078c8f8347c0408304ead8565d4ba8164"
+checksum = "e9ce3ee15eff7fa642791966d427f185184df3c7f4e58893705f3e7781da8ef5"
 dependencies = [
  "array-bytes 6.1.0",
  "async-channel",
@@ -10537,6 +10507,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-beefy",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-keystore",
  "sp-mmr-primitives",
  "sp-runtime",
@@ -10548,9 +10519,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-beefy-rpc"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4e3602efe1e206032164772c24365642e3dab807c5f8db0af166f6ef63af3e"
+checksum = "2a1ed5e8ac2cb53c6a248c8f469353f55bd23c72f23fe371ac19c1d46618de1a"
 dependencies = [
  "futures 0.3.28",
  "jsonrpsee",
@@ -10568,9 +10539,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-epochs"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0befddf2ca16d5f222968fceeab8625532f2d49303fafd17ae2e5d0e939da6"
+checksum = "19f68ddb91626f901578515eed93c7919f739660161f4e9f7b9407e2d0ede981"
 dependencies = [
  "fork-tree",
  "parity-scale-codec",
@@ -10582,9 +10553,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a824457a3384e7bc19d7ee587dffa5b646deb81a2351be0dd075c2110a3d677a"
+checksum = "7ae91e5b5a120be4d13a59eaf94fd85d7c7af528482b8e21d861fa1167df3083"
 dependencies = [
  "ahash 0.8.3",
  "array-bytes 6.1.0",
@@ -10597,7 +10568,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "sc-block-builder",
  "sc-chain-spec",
  "sc-client-api",
@@ -10617,6 +10588,7 @@ dependencies = [
  "sp-consensus",
  "sp-consensus-grandpa",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-keystore",
  "sp-runtime",
  "substrate-prometheus-endpoint",
@@ -10625,9 +10597,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-grandpa-rpc"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "694328880bf11fce67f5e066d7884dbdf1f2a41c42a7dfce9b0a6bc6b90448a1"
+checksum = "697cbd528516561dbc818a8990d5477169e86d9335a0b29207cf6f6a90269e7c"
 dependencies = [
  "finality-grandpa",
  "futures 0.3.28",
@@ -10646,9 +10618,9 @@ dependencies = [
 
 [[package]]
 name = "sc-consensus-slots"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6649665fcf91d89c16bfb08e9326baf6547e5fe719d6438197434e5b642d716b"
+checksum = "567bddd65d52951fb9bc7a7e05d1dfdfc47ff2c594ec5ca9756d27e7226635bb"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -10670,9 +10642,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3129f8af1f8aa5b05829ffec942feff61163054a536704ba48fdcc2276f6042a"
+checksum = "aa2ac6c356538d67987bbb867e11a12a84ba87250c70fd50005b6d74f570a4f7"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -10693,9 +10665,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-common"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0285a4a14c0d2c1d04380ff83cddd79181ded510c605d36804cb9c6eb3bbf2ae"
+checksum = "07498138dee3ddf2c71299ca372d8449880bb3a8a8a299a483094e9c26b0823e"
 dependencies = [
  "sc-allocator",
  "sp-maybe-compressed-blob",
@@ -10706,9 +10678,9 @@ dependencies = [
 
 [[package]]
 name = "sc-executor-wasmtime"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c2ba6ea0e68400caf4847fbcfca6123952b05a817e06f024e9cbafa665ac9d8"
+checksum = "30a387779ab54ec1ffce0bf3a6631faada079459d42796c1895683767918a642"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -10725,9 +10697,9 @@ dependencies = [
 
 [[package]]
 name = "sc-informant"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e07d2dde727c30974767aed4cddd241447c0a800b702662b529dd2e32a10db1"
+checksum = "eb603a0a703f1bc10a4e6462bec1036d8fb8b3e3eff5513a9c07f98ccb8d662d"
 dependencies = [
  "ansi_term",
  "futures 0.3.28",
@@ -10743,9 +10715,9 @@ dependencies = [
 
 [[package]]
 name = "sc-keystore"
-version = "25.0.0"
+version = "26.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93acb7f7c6e5e4be067e78b782a35d1a6d34dafcd955975a1aec05cab9dbf8fe"
+checksum = "4cc4f6a558dd23e3bae2e9f195da822465258b9aaf211c34360d7f6efb944e54"
 dependencies = [
  "array-bytes 6.1.0",
  "parking_lot 0.12.1",
@@ -10758,9 +10730,9 @@ dependencies = [
 
 [[package]]
 name = "sc-mixnet"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cac7d7145c712c4a8b184b3979fe1a154c200ebb1b9f11f1e4e39db97a389f8"
+checksum = "45fb213c15679fe5b87c383815d7fb758c70d3e7c573948bd7fe26ff344d2272"
 dependencies = [
  "array-bytes 4.2.0",
  "arrayvec 0.7.4",
@@ -10788,9 +10760,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f2f49eccabc1de61ff976a184f5380a230f07baa5cb075a31c8ec9459fcd076"
+checksum = "f231c7d5e749ec428b4cfa669d759ae76cd3da4f50d7352a2d711acdc7532891"
 dependencies = [
  "array-bytes 6.1.0",
  "async-channel",
@@ -10810,7 +10782,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "partial_sort",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-client-api",
  "sc-network-common",
  "sc-utils",
@@ -10832,16 +10804,16 @@ dependencies = [
 
 [[package]]
 name = "sc-network-bitswap"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2779d97eff742c1ebcce812bfd154a7273c2c2eb02e11fad76cf7eb583365834"
+checksum = "e2f89b0134738cb3d982b6e625ca93ae8dbe83ce2a06e4b6a396e4df09ed3499"
 dependencies = [
  "async-channel",
  "cid",
  "futures 0.3.28",
  "libp2p-identity",
  "log",
- "prost",
+ "prost 0.12.3",
  "prost-build",
  "sc-client-api",
  "sc-network",
@@ -10853,9 +10825,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-common"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b798acc12d5b3120b2d5e8a078fcec39d6732089261136ac31c993235ade917"
+checksum = "3504bbff5ab016948dbab0f21a8be26324810b76eff3627ce744adb5bfc1b3ce"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
@@ -10871,9 +10843,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-gossip"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd92792f3a04fcb1f21018c9f8a5d6d438d705a2548ffcdc7730280c667b8386"
+checksum = "dad02cf809c34b53614fa61377e3289064edf6c78eb11df071d11fbf7546d7e9"
 dependencies = [
  "ahash 0.8.3",
  "futures 0.3.28",
@@ -10891,9 +10863,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-light"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e7a126492850dbbd5cf0b77ec3ad350422c2822d165941ddbe618a76af0153"
+checksum = "38d84ef0b212c775f58e0304ec09166089f6b09afddf559b7c2b5702933b3be4"
 dependencies = [
  "array-bytes 6.1.0",
  "async-channel",
@@ -10901,7 +10873,7 @@ dependencies = [
  "libp2p-identity",
  "log",
  "parity-scale-codec",
- "prost",
+ "prost 0.12.3",
  "prost-build",
  "sc-client-api",
  "sc-network",
@@ -10913,9 +10885,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-sync"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4c92fd35c49f748abf0bf420e1e99aa76b0f48ab43c183ea5dacef951116d7e"
+checksum = "9aa9377059deece4e7d419d9ec456f657268c0c603e1cf98df4a920f6da83461"
 dependencies = [
  "array-bytes 6.1.0",
  "async-channel",
@@ -10927,7 +10899,7 @@ dependencies = [
  "log",
  "mockall",
  "parity-scale-codec",
- "prost",
+ "prost 0.12.3",
  "prost-build",
  "sc-client-api",
  "sc-consensus",
@@ -10950,9 +10922,9 @@ dependencies = [
 
 [[package]]
 name = "sc-network-transactions"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99a1af3b9e158fa91df0cd92916b3ee5d8b8a14a2b61eb5dd9e36e045808f644"
+checksum = "16c9cad4baf348725bd82eadcd1747fc112ec49c76b863755ce79c588fa73fe4"
 dependencies = [
  "array-bytes 6.1.0",
  "futures 0.3.28",
@@ -10970,9 +10942,9 @@ dependencies = [
 
 [[package]]
 name = "sc-offchain"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd5408dbdc3fe345813e983bd2b7ecf8f20e996141fa39a36336f511ab1859bb"
+checksum = "1aee89f2abd406356bfd688bd7a51155dc963259e4b752bb85d1f8a061a194fd"
 dependencies = [
  "array-bytes 6.1.0",
  "bytes",
@@ -10987,7 +10959,7 @@ dependencies = [
  "once_cell",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "sc-client-api",
  "sc-network",
  "sc-network-common",
@@ -11015,9 +10987,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac0d83b9117c9c004e58331a593a28044eaf6414e5b3c605d1571b4a6981966"
+checksum = "4a5acf6d89f062d1334a0c5b67e9dea97666cd47a49acb2696eab55ff1a1bf74"
 dependencies = [
  "futures 0.3.28",
  "jsonrpsee",
@@ -11048,9 +11020,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-api"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630e81a436f32487452ae1a57ad0ba31f320ddf864bb7faefd7490fe16b3e139"
+checksum = "e9db6aaabfa7e0c27ec15d0f0a11b994cd4bcf86e362f0d9732b4a414d793f0f"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11069,9 +11041,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-server"
-version = "11.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b623908525a2f22aafa079080aa7fbce8b58ca8de53b9f31e3cc8547e0ad8b2"
+checksum = "691440bbaddd3bc2675309c965cc75f8bf694f51e0a28039bfc9658299fbc394"
 dependencies = [
  "http",
  "jsonrpsee",
@@ -11085,9 +11057,9 @@ dependencies = [
 
 [[package]]
 name = "sc-rpc-spec-v2"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a54150c808fa10364b73faedd97aff0977a911a521d1caa8bad2bdc7943ad579"
+checksum = "a7f10275c62296a785f6e2ac716521e3b6e0fae470416fdf86491cbbfcc2e23d"
 dependencies = [
  "array-bytes 6.1.0",
  "futures 0.3.28",
@@ -11099,6 +11071,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "sc-chain-spec",
  "sc-client-api",
+ "sc-rpc",
  "sc-transaction-pool-api",
  "sc-utils",
  "serde",
@@ -11115,9 +11088,9 @@ dependencies = [
 
 [[package]]
 name = "sc-service"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703bd8b1fc0a137185bfa0b654e04283a58a1d8a2751380e7a0eca919961f150"
+checksum = "e14ea779b8c5bdb0d0199c8beebcf1fdc5641e468c480e1c4684be660c8c90af"
 dependencies = [
  "async-trait",
  "directories",
@@ -11129,7 +11102,7 @@ dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-chain-spec",
  "sc-client-api",
  "sc-client-db",
@@ -11168,7 +11141,7 @@ dependencies = [
  "sp-transaction-storage-proof",
  "sp-trie",
  "sp-version",
- "static_init 1.0.3",
+ "static_init",
  "substrate-prometheus-endpoint",
  "tempfile",
  "thiserror",
@@ -11179,9 +11152,9 @@ dependencies = [
 
 [[package]]
 name = "sc-state-db"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac20128b09ac6305aaf482a72c918b35400f3955d7032971df499b0661a5e76"
+checksum = "aa842052c41ad379eaecdfddc0d5c953d57e311ae688233f68f461b91d38da0a"
 dependencies = [
  "log",
  "parity-scale-codec",
@@ -11191,9 +11164,9 @@ dependencies = [
 
 [[package]]
 name = "sc-storage-monitor"
-version = "0.16.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "838d31b4316424d1c2c3a2f06f4e76cd56b53f38d366fc9882444d4ce8faabec"
+checksum = "26cb401aad6732700c8d866cbbef1175b9aeb8230908aff27059ef14bd058ef3"
 dependencies = [
  "clap",
  "fs4",
@@ -11205,9 +11178,9 @@ dependencies = [
 
 [[package]]
 name = "sc-sync-state-rpc"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb310dce9d2474a74152605dc0ca0f81a46f61ba4e7a39752f1203121f47c0c6"
+checksum = "9bc382c7d997f4531eee5e5d57f970eaf2761d722298d7747385a4ad69fa6b12"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -11225,30 +11198,31 @@ dependencies = [
 
 [[package]]
 name = "sc-sysinfo"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfc9a5da78281735c6ff3b8d0287e95dcf32fc001415ac20cb2844c0ab4e6d05"
+checksum = "25d2ab8f15021916a07cfbe7a08be484c5dc7d57f07bc0e2aa03260b55a5632f"
 dependencies = [
  "derive_more",
  "futures 0.3.28",
  "libc",
  "log",
- "rand 0.8.5",
+ "rand",
  "rand_pcg",
  "regex",
  "sc-telemetry",
  "serde",
  "serde_json",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-io",
  "sp-std",
 ]
 
 [[package]]
 name = "sc-telemetry"
-version = "15.0.0"
+version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96841bdc22e1ad5931e6cb7557b06ef33aeda7f5eef3864653359840f9fd025a"
+checksum = "0673a93aa0684b606abfc5fce6c882ada7bb5fad8a2ddc66a09a42bcc9664d91"
 dependencies = [
  "chrono",
  "futures 0.3.28",
@@ -11256,7 +11230,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.1",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "sc-utils",
  "serde",
  "serde_json",
@@ -11266,9 +11240,9 @@ dependencies = [
 
 [[package]]
 name = "sc-tracing"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90864e5e042d1238bcb082b0fa73ce58b7eb4897127783dae1dd66eee59cdaef"
+checksum = "e77b4fdb4f359f19c395ba862430f3ca0efb50b0310b09753caaa06997edd606"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -11309,9 +11283,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7985fab634814ee28fe3ecd2131fa2cb4c8eee88a7e60f1cd59dc0afa826fe2"
+checksum = "326dc8ea417c53b6787bd1bb27431d44768504451f5ce4efdde0c15877c7c121"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -11327,6 +11301,7 @@ dependencies = [
  "sp-api",
  "sp-blockchain",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-runtime",
  "sp-tracing",
  "sp-transaction-pool",
@@ -11336,9 +11311,9 @@ dependencies = [
 
 [[package]]
 name = "sc-transaction-pool-api"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3402336f81a52fd6b1fd5a16fa3f4279032de1e113fe4a973865bf0b0e28679c"
+checksum = "93ae888ce3491acb1b489c3dba930d0c46c7ef9f9893ba0ab8af9125362f3d14"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -11353,9 +11328,9 @@ dependencies = [
 
 [[package]]
 name = "sc-utils"
-version = "14.0.0"
+version = "15.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4d5d1f106d670dd0c56fe540e8b0916aaeff6960bb39440ed8f3c80b52f8d4"
+checksum = "28b1a238f5baa56405db4e440e2d2f697583736fa2e2f1aac345c438a42975f1"
 dependencies = [
  "async-channel",
  "futures 0.3.28",
@@ -11422,9 +11397,7 @@ dependencies = [
  "arrayref",
  "arrayvec 0.5.2",
  "curve25519-dalek 2.1.3",
- "getrandom 0.1.16",
  "merlin 2.0.1",
- "rand 0.7.3",
  "rand_core 0.5.1",
  "sha2 0.8.2",
  "subtle 2.4.1",
@@ -11789,9 +11762,9 @@ checksum = "826167069c09b99d56f31e9ae5c99049e932a98c9dc2dac47645b08dbbf76ba7"
 
 [[package]]
 name = "slot-range-helper"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d9bb569dc58f1e139c20f532a2ad13d54795060c0000c2c49dc812b17684197"
+checksum = "d40fa5e14772407fd2ccffdd5971bf055bbf46a40727c0ea96d2bb6563d17e1c"
 dependencies = [
  "enumn",
  "parity-scale-codec",
@@ -11868,7 +11841,7 @@ dependencies = [
  "pbkdf2 0.12.2",
  "pin-project",
  "poly1305 0.8.0",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "ruzstd",
  "schnorrkel 0.10.2",
@@ -11911,7 +11884,7 @@ dependencies = [
  "no-std-net",
  "parking_lot 0.12.1",
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "serde",
  "serde_json",
@@ -11978,15 +11951,15 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.8.5",
+ "rand",
  "sha-1",
 ]
 
 [[package]]
 name = "sp-api"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dea138c6dbf282ab57756492f0232ea0a08575ca9cbe2b7b1ead49000f238a7"
+checksum = "6ef42aa652381ade883c14ffbbb5c0fec36d382d2217b5bace01b8a0e8634778"
 dependencies = [
  "hash-db",
  "log",
@@ -12021,9 +11994,9 @@ dependencies = [
 
 [[package]]
 name = "sp-application-crypto"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e4fe7a9b7fa9da76272b201e2fb3c7900d97d32a46b66af9a04dad457f73c71"
+checksum = "547cad7a6eabb52c639ec117b3db9c6b43cf1b29a9393b18feb19e101a91833f"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12035,9 +12008,9 @@ dependencies = [
 
 [[package]]
 name = "sp-arithmetic"
-version = "23.0.0"
+version = "24.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f42721f072b421f292a072e8f52a3b3c0fbc27428f0c9fe24067bc47046bad63"
+checksum = "afa823ca5adc490d47dccb41d69ad482bc57a317bd341de275868378f48f131c"
 dependencies = [
  "integer-sqrt",
  "num-traits",
@@ -12050,9 +12023,9 @@ dependencies = [
 
 [[package]]
 name = "sp-authority-discovery"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a740c05e9096eb17e93b5ab6aa5fe8ce0c9b4243777826d92133b3dd682e14"
+checksum = "c92b177c72b5d2973c36d60f6ef942d791d9fd91eae8b08c71882e4118d4fbfc"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12064,9 +12037,9 @@ dependencies = [
 
 [[package]]
 name = "sp-block-builder"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6d2aa0943101367b955f5806c3ecea2e23df7c90059708107470dbfb9d3d7ab"
+checksum = "1b36ce171caa7eb2bbe682c089f755fdefa71d3702e4fb1ba30d10146aef99d5"
 dependencies = [
  "sp-api",
  "sp-inherents",
@@ -12076,9 +12049,9 @@ dependencies = [
 
 [[package]]
 name = "sp-blockchain"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9adee5ddcf0682d0302ed640a285b9f922d933a205b63c7819a74d6092b6f78"
+checksum = "a31303e766d2e53812641bbc1f1cec03a85793fc9e627e55f0a6854b28708758"
 dependencies = [
  "futures 0.3.28",
  "log",
@@ -12095,9 +12068,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfcac16e85f78db9c99c9424659bb25790be079a0b758a3674ee8e1e7ef635b0"
+checksum = "cb6e512b862c4ff7a26cdcd364898cc42e181ff5cb35fbb226ff27d88c81569a"
 dependencies = [
  "async-trait",
  "futures 0.3.28",
@@ -12111,9 +12084,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-aura"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ab8e878a116b0885eaefd068235657737cb72fdce60a8c080dfd092f7d645cc"
+checksum = "4bf13c293685319751f72fa5216c7fb5f25f3e8e8fe29b4503296ed5f5466b3d"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12129,9 +12102,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-babe"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebfedfdea5b22fb3625cd664e72503dcbd1087373181d5be0d092b3e7b4c61f5"
+checksum = "b9be2f86a2f0ce2a78b455feb547aa27604fd76a7f7a691995cbad44e0b1b9dd"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12149,9 +12122,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-beefy"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e09a424196a673f0e6b5fe79e4ab97da416491cfecab7bc835fa595134ac1b5c"
+checksum = "90ff890a84ef57628b010df0e1d75b3a78fb7f575e4ceeba7215c276902c403e"
 dependencies = [
  "lazy_static",
  "parity-scale-codec",
@@ -12160,18 +12133,19 @@ dependencies = [
  "sp-api",
  "sp-application-crypto",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-io",
  "sp-mmr-primitives",
  "sp-runtime",
  "sp-std",
- "strum",
+ "strum 0.24.1",
 ]
 
 [[package]]
 name = "sp-consensus-grandpa"
-version = "13.0.0"
+version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a906b20409a5a69b1d9580848f502af20cf2c51a1ae028ba208375eb11f332b"
+checksum = "64b606164600db36e596db7abf32b4533dc9a74526d9444c4c45035427b2199b"
 dependencies = [
  "finality-grandpa",
  "log",
@@ -12188,9 +12162,9 @@ dependencies = [
 
 [[package]]
 name = "sp-consensus-slots"
-version = "0.32.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc5c1620d81196391daa15e78ea20cc11c59f08c509381c276d5d6a3d4d36af"
+checksum = "73a5bd1fcd84bbdc7255528c7cdb92f9357fd555f06ee553af7e340cbdab517c"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12201,9 +12175,9 @@ dependencies = [
 
 [[package]]
 name = "sp-core"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f230cb12575455070da0fc174815958423a0b9a641d5e304a9457113c7cb4007"
+checksum = "7c33c7a1568175250628567d50c4e1c54a6ac5bc1190413b9be29a9e810cbe73"
 dependencies = [
  "array-bytes 6.1.0",
  "bip39",
@@ -12225,13 +12199,13 @@ dependencies = [
  "parking_lot 0.12.1",
  "paste",
  "primitive-types",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnorrkel 0.11.4",
  "secp256k1",
  "secrecy",
  "serde",
- "sp-core-hashing",
+ "sp-crypto-hashing",
  "sp-debug-derive",
  "sp-externalities",
  "sp-runtime-interface",
@@ -12246,10 +12220,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-core-hashing"
-version = "15.0.0"
+name = "sp-crypto-hashing"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0f4990add7b2cefdeca883c0efa99bb4d912cb2196120e1500c0cc099553b0"
+checksum = "bc9927a7f81334ed5b8a98a4a978c81324d12bd9713ec76b5c68fd410174c5eb"
 dependencies = [
  "blake2b_simd",
  "byteorder",
@@ -12260,13 +12234,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "sp-core-hashing-proc-macro"
-version = "15.0.0"
+name = "sp-crypto-hashing-proc-macro"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7527f8dda7667c41009b2cd0efaddcb81709b9741bd5ee6d17b11bad835cc698"
+checksum = "b85d0f1f1e44bd8617eb2a48203ee854981229e3e79e6f468c7175d5fd37489b"
 dependencies = [
  "quote",
- "sp-core-hashing",
+ "sp-crypto-hashing",
  "syn 2.0.50",
 ]
 
@@ -12293,9 +12267,9 @@ dependencies = [
 
 [[package]]
 name = "sp-externalities"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63867ec85950ced90d4ab1bba902a47db1b1efdf2829f653945669b2bb470a9c"
+checksum = "e7096ed024cec397804864898b093b51e14c7299f1d00c67dd5800330e02bb82"
 dependencies = [
  "environmental",
  "parity-scale-codec",
@@ -12305,9 +12279,9 @@ dependencies = [
 
 [[package]]
 name = "sp-genesis-builder"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfdc79df83221ec5a279cbbd08fd6f8be164b9b081c8e84593ce2c2ebd5d66c0"
+checksum = "fd865540ec19479c7349b584ccd78cc34c3f3a628a2a69dbb6365ceec36295ee"
 dependencies = [
  "serde_json",
  "sp-api",
@@ -12317,9 +12291,9 @@ dependencies = [
 
 [[package]]
 name = "sp-inherents"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3caf2d1288549d7e6c32b453f2d4855d498bb88600101011e35653e022a6f2"
+checksum = "607c9e35e96966645ff180a9e9f976433b96e905d0a91d8d5315e605a21f4bc0"
 dependencies = [
  "async-trait",
  "impl-trait-for-tuples",
@@ -12332,9 +12306,9 @@ dependencies = [
 
 [[package]]
 name = "sp-io"
-version = "30.0.0"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c55f26d89feedaf0faf81688b6e1e1e81329cd8b4c6a4fd6c5b97ed9dd068b8a"
+checksum = "ec43aa073eab35fcb920d7592474d5427ea3be2bf938706a3ad955d7ba54fd8d"
 dependencies = [
  "bytes",
  "ed25519-dalek",
@@ -12344,6 +12318,7 @@ dependencies = [
  "rustversion",
  "secp256k1",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-externalities",
  "sp-keystore",
  "sp-runtime-interface",
@@ -12357,20 +12332,20 @@ dependencies = [
 
 [[package]]
 name = "sp-keyring"
-version = "31.0.0"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98165ce7c625a8cdb88d39c6bbd56fe8b32ada64ed0894032beba99795f557da"
+checksum = "69cf0a2f881958466fc92bc9b39bbc2c0d815ded4a21f8f953372b0ac2e11b02"
 dependencies = [
  "sp-core",
  "sp-runtime",
- "strum",
+ "strum 0.24.1",
 ]
 
 [[package]]
 name = "sp-keystore"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96806a28a62ed9ddecd0b28857b1344d029390f7c5c42a2ff9199cbf5638635c"
+checksum = "444f2d53968b1ce5e908882710ff1f3873fcf3e95f59d57432daf685bbacb959"
 dependencies = [
  "parity-scale-codec",
  "parking_lot 0.12.1",
@@ -12403,9 +12378,9 @@ dependencies = [
 
 [[package]]
 name = "sp-mixnet"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ed83d2f899484bde61c72cbae6edfb25708d43e6b19934e206f3c706df67df"
+checksum = "7bebd44b915c65aeb7e7eeaea466aba3b27cdd915c83ea83d4643c54f21ffbbf"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12416,9 +12391,9 @@ dependencies = [
 
 [[package]]
 name = "sp-mmr-primitives"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7526a73d518c03fa2447588b1544019a194a4f113cf34d2610d3b5925c80c86"
+checksum = "891b7263b7c44a569173ee1078f68fb1a01991a44914607c0100aa5ae41f6562"
 dependencies = [
  "ckb-merkle-mountain-range",
  "log",
@@ -12435,9 +12410,9 @@ dependencies = [
 
 [[package]]
 name = "sp-npos-elections"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa8efff28b504b4b928288976e5f72c00c7ece9d2348a7ca2496c77849dd4c8f"
+checksum = "195d7e1154c91cce5c3abc8c778689c3e5799da6411328dd32ac7a974c68e526"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12450,9 +12425,9 @@ dependencies = [
 
 [[package]]
 name = "sp-offchain"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb45b3e397dc9c7b81cb2d8d641d0bcb1f525b60e83835783413ba73b3f61ac9"
+checksum = "4d83b955dce0b6d143bec3f60571311168f362b1c16cf044da7037a407b66c19"
 dependencies = [
  "sp-api",
  "sp-core",
@@ -12472,9 +12447,9 @@ dependencies = [
 
 [[package]]
 name = "sp-rpc"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a55f2c7660b579627d22932ecfe2e5f001a7671d2fa77667387517c7f80e6fb"
+checksum = "9af4b73fe7ddd88b1641cca90048c4e525e721763199e6fd29c4f590884f4d16"
 dependencies = [
  "rustc-hash",
  "serde",
@@ -12483,9 +12458,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime"
-version = "31.0.1"
+version = "32.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3bb49a4475d390198dfd3d41bef4564ab569fbaf1b5e38ae69b35fc01199d91"
+checksum = "0a95e71603a6281e91b0f1fd3d68057644be16d75a4602013187b8137db8abee"
 dependencies = [
  "docify",
  "either",
@@ -12494,7 +12469,7 @@ dependencies = [
  "log",
  "parity-scale-codec",
  "paste",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "serde",
  "simple-mermaid",
@@ -12508,9 +12483,9 @@ dependencies = [
 
 [[package]]
 name = "sp-runtime-interface"
-version = "24.0.0"
+version = "25.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66b66d8cec3d785fa6289336c1d9cbd4305d5d84f7134378c4d79ed7983e6fb"
+checksum = "4e2321ab29d4bcc31f1ba1b4f076a81fb2a666465231e5c981c72320d74dbe63"
 dependencies = [
  "bytes",
  "impl-trait-for-tuples",
@@ -12541,9 +12516,9 @@ dependencies = [
 
 [[package]]
 name = "sp-session"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8048981db53d4f5171e6003f5e11fbfc27a8c196b0827619907a4214746a623b"
+checksum = "3b86531090cc04d2ab3535df07146258e2fb3ab6257b0a77ef14aa08282c3d4a"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -12557,9 +12532,9 @@ dependencies = [
 
 [[package]]
 name = "sp-staking"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0e68be3fff84dd8ee552f9d13dd2e9eab3663e0bddfc6c6c88de02aaca1e311"
+checksum = "1e14d003ecf0b610bf1305a92bdab875289b39d514c073f30e75e78c2763a788"
 dependencies = [
  "impl-trait-for-tuples",
  "parity-scale-codec",
@@ -12572,15 +12547,15 @@ dependencies = [
 
 [[package]]
 name = "sp-state-machine"
-version = "0.35.0"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "718c779ad1d6fcc0be64c7ce030b33fa44b5c8914b3a1319ef63bb5f27fb98df"
+checksum = "a67297e702aa32027d7766803f362a420d6d3ec9e2f84961f3c64e2e52b5aaf9"
 dependencies = [
  "hash-db",
  "log",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "sp-core",
  "sp-externalities",
@@ -12594,21 +12569,22 @@ dependencies = [
 
 [[package]]
 name = "sp-statement-store"
-version = "10.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fee6d4ceb2513f180e6e017fd6d6f3c9a1a122dcedee5fc8e4254d8a7ecf793d"
+checksum = "309a9ae4e8134bbed8ffc510cf4d461a4a651f9250b556de782cedd876abe1ff"
 dependencies = [
  "aes-gcm 0.10.2",
  "curve25519-dalek 4.1.1",
  "ed25519-dalek",
  "hkdf",
  "parity-scale-codec",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "sha2 0.10.8",
  "sp-api",
  "sp-application-crypto",
  "sp-core",
+ "sp-crypto-hashing",
  "sp-externalities",
  "sp-runtime",
  "sp-runtime-interface",
@@ -12625,9 +12601,9 @@ checksum = "12f8ee986414b0a9ad741776762f4083cd3a5128449b982a3919c4df36874834"
 
 [[package]]
 name = "sp-storage"
-version = "19.0.0"
+version = "20.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fb92d7b24033a8a856d6e20dd980b653cbd7af7ec471cc988b1b7c1d2e3a32b"
+checksum = "8dba5791cb3978e95daf99dad919ecb3ec35565604e88cd38d805d9d4981e8bd"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
@@ -12639,9 +12615,9 @@ dependencies = [
 
 [[package]]
 name = "sp-timestamp"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "347eaddd5b07856ccec69ac3300e72e392a5efc3aea5fb4b7230888a0b447b9e"
+checksum = "249cd06624f2edb53b25af528ab216a508dc9d0870e158b43caac3a97e86699f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12666,9 +12642,9 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-pool"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97c4052e69eacdb7a411e050c56a838f460b8a879071125451e9bb2d4814df34"
+checksum = "9742861c5330bdcb42856a6eed3d3745b58ee1c92ca4c9260032ff4e6c387165"
 dependencies = [
  "sp-api",
  "sp-runtime",
@@ -12676,9 +12652,9 @@ dependencies = [
 
 [[package]]
 name = "sp-transaction-storage-proof"
-version = "26.0.0"
+version = "27.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b2a2c693bc7ca363c9d2cd412276582aef10c794399aaffbd1fe2351099a1a5"
+checksum = "ece8e22a5419c7a336a2544654e1389fec8cac19b93081a30912842b44e8167f"
 dependencies = [
  "async-trait",
  "parity-scale-codec",
@@ -12692,9 +12668,9 @@ dependencies = [
 
 [[package]]
 name = "sp-trie"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e4d24d84a0beb44a71dcac1b41980e1edf7fb722c7f3046710136a283cd479b"
+checksum = "eed48dfd05081e8b36741b10ce4eb686c135a2952227a11fe71caec89890ddbb"
 dependencies = [
  "ahash 0.8.3",
  "hash-db",
@@ -12703,7 +12679,7 @@ dependencies = [
  "nohash-hasher",
  "parity-scale-codec",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "scale-info",
  "schnellru",
  "sp-core",
@@ -12717,16 +12693,16 @@ dependencies = [
 
 [[package]]
 name = "sp-version"
-version = "29.0.0"
+version = "30.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd1b053394347e22f541696bca4a9ac3ec848b50d1b86f5018d2b771f39f11a"
+checksum = "ff4a660c68995663d6778df324f4e2b4efc48d55a8e9c92c22a5fb7dae7899cd"
 dependencies = [
  "impl-serde",
  "parity-scale-codec",
  "parity-wasm",
  "scale-info",
  "serde",
- "sp-core-hashing-proc-macro",
+ "sp-crypto-hashing-proc-macro",
  "sp-runtime",
  "sp-std",
  "sp-version-proc-macro",
@@ -12761,9 +12737,9 @@ dependencies = [
 
 [[package]]
 name = "sp-weights"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e874bdf9dd3fd3242f5b7867a4eaedd545b02f29041a46d222a9d9d5caaaa5c"
+checksum = "a3be30aec904994451dcacf841a9168cfbbaf817de6b24b6a1c1418cbf1af2fe"
 dependencies = [
  "bounded-collections",
  "parity-scale-codec",
@@ -12795,7 +12771,7 @@ checksum = "08615eea740067d9899969bc2891c68a19c315cb1f66640af9a9ecb91b13bcab"
 dependencies = [
  "lazy_static",
  "maplit",
- "strum",
+ "strum 0.24.1",
 ]
 
 [[package]]
@@ -12831,9 +12807,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "staging-parachain-info"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad554ffd27fbcafd82e234d7e7188e458e51bfe2b3b5000dd236dce762e3e95f"
+checksum = "da7dc139d104f676a18c13380a09c3f72d59450a7471116387cbf8cb5f845a0e"
 dependencies = [
  "cumulus-primitives-core",
  "frame-support",
@@ -12846,9 +12822,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df18af00766d22926916bb443f14742c65cc6b2f0fe997b8f26da0d0f9ee9ca"
+checksum = "5ccecaeae5eca8453760e96fcf65481b19898459971842004732e88cd3570741"
 dependencies = [
  "array-bytes 6.1.0",
  "bounded-collections",
@@ -12865,9 +12841,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-builder"
-version = "7.0.3"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ba4f214fe99d79ffcc266f431abbb32d3596788327b925d469c7bb6a3c84d3c"
+checksum = "a8f6cfc27c1d45f9a67e20ed3f7e60296299688825350291606add10bf3bbff2"
 dependencies = [
  "frame-support",
  "frame-system",
@@ -12888,9 +12864,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm-executor"
-version = "7.0.3"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f1dea1e33eefee513c197c24255670951a2c515a6ce2c7049fe86385400074f"
+checksum = "a638f4c8735cc04b5c93920a1f59e679f48b131315a07d146798e0decebf7720"
 dependencies = [
  "environmental",
  "frame-benchmarking",
@@ -12916,18 +12892,6 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "static_init"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11b73400442027c4adedda20a9f9b7945234a5bd8d5f7e86da22bd5d0622369c"
-dependencies = [
- "cfg_aliases",
- "libc",
- "parking_lot 0.11.2",
- "static_init_macro 0.5.0",
-]
-
-[[package]]
-name = "static_init"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a2a1c578e98c1c16fc3b8ec1328f7659a500737d7a0c6d625e73e830ff9c1f6"
@@ -12937,21 +12901,8 @@ dependencies = [
  "libc",
  "parking_lot 0.11.2",
  "parking_lot_core 0.8.6",
- "static_init_macro 1.0.2",
+ "static_init_macro",
  "winapi",
-]
-
-[[package]]
-name = "static_init_macro"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2261c91034a1edc3fc4d1b80e89d82714faede0515c14a75da10cb941546bbf"
-dependencies = [
- "cfg_aliases",
- "memchr",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -12992,8 +12943,14 @@ version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.24.3",
 ]
+
+[[package]]
+name = "strum"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
 
 [[package]]
 name = "strum_macros"
@@ -13009,10 +12966,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "substrate-bip39"
-version = "0.4.4"
+name = "strum_macros"
+version = "0.25.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49eee6965196b32f882dd2ee85a92b1dbead41b04e53907f269de3b0dc04733c"
+checksum = "23dc1fa9ac9c169a78ba62f0b841814b7abae11bdd047b9c58f893439e309ea0"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.50",
+]
+
+[[package]]
+name = "substrate-bip39"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e620c7098893ba667438b47169c00aacdd9e7c10e042250ce2b60b087ec97328"
 dependencies = [
  "hmac 0.11.0",
  "pbkdf2 0.8.0",
@@ -13041,9 +13011,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-frame-rpc-system"
-version = "28.0.0"
+version = "29.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcee7812a1e1cec85e3095c5d1c1627ceb084c0c81e66c2f9df7cb7b3a5938f3"
+checksum = "332f903d2f34703204f0003136c9abbc569d691028279996a1daf8f248a7369f"
 dependencies = [
  "frame-system-rpc-runtime-api",
  "futures 0.3.28",
@@ -13085,9 +13055,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-rpc-client"
-version = "0.33.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9076480cc6f480429b081bf93607d32183bdac4d6f0d2969d5e08de08bea1701"
+checksum = "40e5235d8460ec81e9a382345aa80d75e2943f224a332559847344bb62fa13b3"
 dependencies = [
  "async-trait",
  "jsonrpsee",
@@ -13099,9 +13069,9 @@ dependencies = [
 
 [[package]]
 name = "substrate-state-trie-migration-rpc"
-version = "27.0.0"
+version = "28.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c92c25dcb3e4aee5559c2bd9b4d105786220cad116719d7ebb39e4f359865d44"
+checksum = "5768a5d3c76eebfdf94c23a3fde6c832243a043d60561e5ac1a2b475b9ad09f3"
 dependencies = [
  "jsonrpsee",
  "parity-scale-codec",
@@ -13127,17 +13097,17 @@ dependencies = [
 
 [[package]]
 name = "substrate-wasm-builder"
-version = "17.0.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac08d23ff4da66fe6cb0300f249be010d78e5abeafef0390cae39736a374e6cd"
+checksum = "511bbc2df035f5fe2556d855369a1bbb45df620360391a1f6e3fa1a1d64af79a"
 dependencies = [
- "ansi_term",
  "build-helper",
  "cargo_metadata",
+ "console",
  "filetime",
  "parity-wasm",
  "sp-maybe-compressed-blob",
- "strum",
+ "strum 0.24.1",
  "tempfile",
  "toml 0.8.10",
  "walkdir",
@@ -13215,21 +13185,6 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
-]
-
-[[package]]
-name = "system-parachains-constants"
-version = "1.0.0"
-source = "git+https://github.com/encointer/runtimes.git?branch=ab/upgrade-polkadot-v1.6.0#437115e766f49b884aa1b5633dc83893b4a76fd1"
-dependencies = [
- "frame-support",
- "kusama-runtime-constants",
- "parachains-common",
- "polkadot-core-primitives",
- "polkadot-primitives",
- "polkadot-runtime-constants",
- "smallvec",
- "sp-runtime",
 ]
 
 [[package]]
@@ -13468,7 +13423,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
 dependencies = [
  "pin-project",
- "rand 0.8.5",
+ "rand",
  "tokio",
 ]
 
@@ -13520,18 +13475,6 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6135d499e69981f9ff0ef2167955a5333c35e36f6937d382974566b3d5b94ec"
-dependencies = [
- "serde",
- "serde_spanned",
- "toml_datetime",
- "toml_edit 0.19.10",
-]
-
-[[package]]
-name = "toml"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a9aad4a3066010876e8dcf5a8a06e70a558751117a145c6ce2b82c2e2054290"
@@ -13558,8 +13501,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2380d56e8670370eee6566b0bfd4265f65b3f432e8c6d85623f728d4fa31f739"
 dependencies = [
  "indexmap 1.9.3",
- "serde",
- "serde_spanned",
  "toml_datetime",
  "winnow 0.4.6",
 ]
@@ -13605,6 +13546,10 @@ version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project",
+ "pin-project-lite 0.2.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -13686,9 +13631,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-gum"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f134d9dda0e872989ddf57b90ca73bcad27f1fba2cc19cfada7b76549c590b0"
+checksum = "9690af7fe11d125786fa1b5ca802192f631b61a4411277865c8e0581c887e286"
 dependencies = [
  "coarsetime",
  "polkadot-primitives",
@@ -13791,7 +13736,7 @@ dependencies = [
  "idna 0.2.3",
  "ipnet",
  "lazy_static",
- "rand 0.8.5",
+ "rand",
  "smallvec",
  "socket2 0.4.9",
  "thiserror",
@@ -13829,9 +13774,9 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "try-runtime-cli"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb82b8de45dabaaba00c8c7394f18c6f97dd0e27954d4de08b352a24886d8407"
+checksum = "9454e1af0a0be675f837d63080ef8f43510c05df8c059570622386a0cf40b548"
 dependencies = [
  "async-trait",
  "clap",
@@ -13877,7 +13822,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 
@@ -14038,7 +13983,7 @@ dependencies = [
  "arrayref",
  "constcat",
  "digest 0.10.7",
- "rand 0.8.5",
+ "rand",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
  "sha2 0.10.8",
@@ -14064,9 +14009,9 @@ checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
-version = "2.3.3"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
+checksum = "d71d857dc86794ca4c280d616f7da00d2dbfd8cd788846559a6813e6aa4b54ee"
 dependencies = [
  "same-file",
  "winapi-util",
@@ -14162,9 +14107,9 @@ checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "wasm-instrument"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa1dafb3e60065305741e83db35c6c2584bb3725b692b5b66148a38d72ace6cd"
+checksum = "2a47ecb37b9734d1085eaa5ae1a81e60801fd8c28d4cabdd8aedb982021918bc"
 dependencies = [
  "parity-wasm",
 ]
@@ -14177,8 +14122,8 @@ checksum = "fc942673e7684671f0c5708fc18993569d184265fd5223bb51fc8e5b9b6cfd52"
 dependencies = [
  "anyhow",
  "libc",
- "strum",
- "strum_macros",
+ "strum 0.24.1",
+ "strum_macros 0.24.3",
  "tempfile",
  "thiserror",
  "wasm-opt-cxx-sys",
@@ -14449,7 +14394,7 @@ dependencies = [
  "memfd",
  "memoffset 0.8.0",
  "paste",
- "rand 0.8.5",
+ "rand",
  "rustix 0.36.14",
  "wasmtime-asm-macros",
  "wasmtime-environ",
@@ -14499,25 +14444,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "webpki-roots"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b03058f88386e5ff5310d9111d53f48b17d732b401aeb83a8d5190f2ac459338"
-dependencies = [
- "rustls-webpki 0.100.3",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
-
-[[package]]
 name = "westend-runtime"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390ccc949904980061c181f0a1507ceb793f3b57f8f930ef60222839e08cb2ca"
+checksum = "db2a5cebb4c678a0d1291bb21f9d44ddebceae044b0fb5200fa3bed108a31595"
 dependencies = [
  "binary-merkle-tree",
  "bitvec",
@@ -14622,9 +14552,9 @@ dependencies = [
 
 [[package]]
 name = "westend-runtime-constants"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c410b8a17b87e5228f9c27ba4a8020e7ece4a8afb0f452b989834623afe84a2"
+checksum = "3b080c193714605ce1033311d85035247adca170181cd68a3ad7e3ca87755a14"
 dependencies = [
  "frame-support",
  "polkadot-primitives",
@@ -15049,9 +14979,9 @@ dependencies = [
 
 [[package]]
 name = "xcm-procedural"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7998facd751c42ec9b11a4cf71fcdb41fb147c5c8db8bcd1281fe84f8760d515"
+checksum = "f4717a97970a9cda70d7db53cf50d2615c2f6f6b7c857445325b4a39ea7aa2cd"
 dependencies = [
  "Inflector",
  "proc-macro2",
@@ -15069,7 +14999,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot 0.12.1",
- "rand 0.8.5",
+ "rand",
  "static_assertions",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "encointer-kusama-runtime"
 version = "1.0.0"
-source = "git+https://github.com/encointer/runtimes.git?branch=bkontur/bko-bump-to-1.7#817f944fbf3ffb9fe582e57aa897c3b2dcd4f616"
+source = "git+https://github.com/encointer/runtimes.git?branch=polkadot-v1.7.0#956696788dcb3a8afcaceaf3c3440d781ce2bc82"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -7579,9 +7579,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "8.0.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0bade2eb6ce40af35a5af150692b4e150638f7f68c15735ab9cdf79650d68e"
+checksum = "d32aa4911002f03a8aebd897e094980e7a9fb25d092e0f8db38e76e1e4f643ee"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -12822,9 +12822,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "8.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccecaeae5eca8453760e96fcf65481b19898459971842004732e88cd3570741"
+checksum = "48fa328b87de3466bc38cc9a07244c42c647b7755b81115e1dfeb47cc13fc6e6"
 dependencies = [
  "array-bytes 6.1.0",
  "bounded-collections",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-collator"
-version = "1.7.0"
+version = "1.7.3"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ color-print = "0.3.4"
 parity-scale-codec = { version = "3.6", default-features = false, features = ["derive"] }
 futures = { version = "0.3.28", features = ["compat"] }
 hex-literal = "0.4.1"
-jsonrpsee = { version = "0.16.3", features = ["server"] }
+jsonrpsee = { version = "0.20.3", features = ["server"] }
 log = { version = "0.4.20", default-features = false }
 nix = "0.24"
 scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
@@ -25,121 +25,121 @@ smallvec = "1.11.2"
 tempfile = "3.8.1"
 
 # encointer deps
-encointer-balances-tx-payment = { default-features = false, version = "5.0.0" }
-encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "5.0.0" }
-encointer-primitives = { default-features = false, version = "5.0.0" }
-pallet-encointer-balances = { default-features = false, version = "5.0.0" }
-pallet-encointer-bazaar = { default-features = false, version = "5.0.0" }
-pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, version = "5.0.0" }
-pallet-encointer-ceremonies = { default-features = false, version = "5.0.0" }
-pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, version = "5.0.0" }
-pallet-encointer-communities = { default-features = false, version = "5.0.0" }
-pallet-encointer-communities-rpc-runtime-api = { default-features = false, version = "5.0.0" }
-pallet-encointer-faucet = { default-features = false, version = "5.0.0" }
-pallet-encointer-reputation-commitments = { default-features = false, version = "5.0.0" }
-pallet-encointer-scheduler = { default-features = false, version = "5.0.0" }
+encointer-balances-tx-payment = { default-features = false, version = "6.0.0" }
+encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "6.0.0" }
+encointer-primitives = { default-features = false, version = "6.0.1" }
+pallet-encointer-balances = { default-features = false, version = "6.0.0" }
+pallet-encointer-bazaar = { default-features = false, version = "6.0.0" }
+pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, version = "6.0.0" }
+pallet-encointer-ceremonies = { default-features = false, version = "6.0.0" }
+pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, version = "6.0.0" }
+pallet-encointer-communities = { default-features = false, version = "6.0.0" }
+pallet-encointer-communities-rpc-runtime-api = { default-features = false, version = "6.0.0" }
+pallet-encointer-faucet = { default-features = false, version = "6.0.0" }
+pallet-encointer-reputation-commitments = { default-features = false, version = "6.0.0" }
+pallet-encointer-scheduler = { default-features = false, version = "6.0.0" }
 # rpc [std]
-pallet-encointer-bazaar-rpc = "5.0.0"
-pallet-encointer-ceremonies-rpc = "5.0.0"
-pallet-encointer-communities-rpc = "5.0.0"
+pallet-encointer-bazaar-rpc = "6.0.0"
+pallet-encointer-ceremonies-rpc = "6.0.0"
+pallet-encointer-communities-rpc = "6.0.0"
 
 # fellowship runtimes
-kusama-runtime-constants = { default-features = false, git = "https://github.com/encointer/runtimes.git", branch = "ab/upgrade-polkadot-v1.6.0" }
-parachain-runtime = { package = "encointer-kusama-runtime", git = "https://github.com/encointer/runtimes.git", branch = "ab/upgrade-polkadot-v1.6.0" }
+kusama-runtime-constants = { default-features = false, git = "https://github.com/encointer/runtimes.git", branch = "bkontur/bko-bump-to-1.7" }
+parachain-runtime = { package = "encointer-kusama-runtime", git = "https://github.com/encointer/runtimes.git", branch = "bkontur/bko-bump-to-1.7" }
 
 # polkadot-sdk [no_std]
-cumulus-pallet-aura-ext = { default-features = false, version = "0.7.0" }
-cumulus-pallet-dmp-queue = { default-features = false, version = "0.7.0" }
-cumulus-pallet-parachain-system = { default-features = false, features = ["parameterized-consensus-hook"], version = "0.7.0" }
-cumulus-pallet-xcm = { default-features = false, version = "0.7.0" }
-cumulus-pallet-xcmp-queue = { default-features = false, version = "0.7.0" }
-cumulus-primitives-core = { default-features = false, version = "0.7.0" }
-cumulus-primitives-timestamp = { default-features = false, version = "0.7.0" }
-cumulus-primitives-utility = { default-features = false, version = "0.7.0" }
-frame-benchmarking = { default-features = false, version = "28.0.0" }
-frame-executive = { default-features = false, version = "28.0.0" }
-frame-rpc-system = { package = "substrate-frame-rpc-system", version = "28.0.0" }
-frame-support = { default-features = false, version = "28.0.0" }
-frame-system = { default-features = false, version = "28.0.0" }
-frame-system-benchmarking = { default-features = false, version = "28.0.0" }
-frame-system-rpc-runtime-api = { default-features = false, version = "26.0.0" }
-frame-try-runtime = { default-features = false, version = "0.34.0" }
-pallet-asset-tx-payment = { default-features = false, version = "28.0.0" }
-pallet-aura = { default-features = false, version = "27.0.0" }
-pallet-balances = { default-features = false, version = "28.0.0" }
-pallet-collective = { default-features = false, version = "28.0.0" }
-pallet-insecure-randomness-collective-flip = { default-features = false, version = "16.0.0" }
-pallet-membership = { default-features = false, version = "28.0.0" }
-pallet-proxy = { default-features = false, version = "28.0.0" }
-pallet-scheduler = { default-features = false, version = "29.0.0" }
-pallet-timestamp = { default-features = false, version = "27.0.0" }
-pallet-transaction-payment = { default-features = false, version = "28.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "28.0.0" }
-pallet-treasury = { default-features = false, version = "27.0.0" }
-pallet-utility = { default-features = false, version = "28.0.0" }
-pallet-xcm = { default-features = false, version = "7.0.0" }
-parachains-common = { default-features = false, version = "7.0.0" }
-parachain-info = { package = "staging-parachain-info", default-features = false, version = "0.7.0" }
-polkadot-core-primitives = { default-features = false, version = "7.0.0" }
-polkadot-parachain-primitives = { default-features = false, version = "6.0.0" }
-polkadot-runtime-common = { default-features = false, version = "7.0.0" }
-sp-api = { default-features = false, version = "26.0.0" }
-sp-block-builder = { default-features = false, version = "26.0.0" }
-sp-consensus-aura = { default-features = false, version = "0.32.0" }
-sp-core = { default-features = false, version = "28.0.0" }
-sp-inherents = { default-features = false, version = "26.0.0" }
-sp-io = { default-features = false, version = "30.0.0" }
-sp-offchain = { default-features = false, version = "26.0.0" }
-sp-runtime = { default-features = false, version = "31.0.0" }
-sp-session = { default-features = false, version = "27.0.0" }
+cumulus-pallet-aura-ext = { default-features = false, version = "0.8.0" }
+cumulus-pallet-dmp-queue = { default-features = false, version = "0.8.0" }
+cumulus-pallet-parachain-system = { default-features = false, features = ["parameterized-consensus-hook"], version = "0.8.0" }
+cumulus-pallet-xcm = { default-features = false, version = "0.8.0" }
+cumulus-pallet-xcmp-queue = { default-features = false, version = "0.8.0" }
+cumulus-primitives-core = { default-features = false, version = "0.8.0" }
+cumulus-primitives-timestamp = { default-features = false, version = "0.8.0" }
+cumulus-primitives-utility = { default-features = false, version = "0.8.0" }
+frame-benchmarking = { default-features = false, version = "29.0.0" }
+frame-executive = { default-features = false, version = "29.0.0" }
+frame-rpc-system = { package = "substrate-frame-rpc-system", version = "29.0.0" }
+frame-support = { default-features = false, version = "29.0.0" }
+frame-system = { default-features = false, version = "29.0.0" }
+frame-system-benchmarking = { default-features = false, version = "29.0.0" }
+frame-system-rpc-runtime-api = { default-features = false, version = "27.0.0" }
+frame-try-runtime = { default-features = false, version = "0.35.0" }
+pallet-asset-tx-payment = { default-features = false, version = "29.0.0" }
+pallet-aura = { default-features = false, version = "28.0.0" }
+pallet-balances = { default-features = false, version = "29.0.0" }
+pallet-collective = { default-features = false, version = "29.0.0" }
+pallet-insecure-randomness-collective-flip = { default-features = false, version = "17.0.0" }
+pallet-membership = { default-features = false, version = "29.0.0" }
+pallet-proxy = { default-features = false, version = "29.0.0" }
+pallet-scheduler = { default-features = false, version = "30.0.0" }
+pallet-timestamp = { default-features = false, version = "28.0.0" }
+pallet-transaction-payment = { default-features = false, version = "29.0.0" }
+pallet-transaction-payment-rpc-runtime-api = { default-features = false, version = "29.0.0" }
+pallet-treasury = { default-features = false, version = "28.0.0" }
+pallet-utility = { default-features = false, version = "29.0.0" }
+pallet-xcm = { default-features = false, version = "8.0.1" }
+parachains-common = { default-features = false, version = "8.0.0" }
+parachain-info = { package = "staging-parachain-info", default-features = false, version = "0.8.0" }
+polkadot-core-primitives = { default-features = false, version = "8.0.0" }
+polkadot-parachain-primitives = { default-features = false, version = "7.0.0" }
+polkadot-runtime-common = { default-features = false, version = "8.0.0" }
+sp-api = { default-features = false, version = "27.0.0" }
+sp-block-builder = { default-features = false, version = "27.0.0" }
+sp-consensus-aura = { default-features = false, version = "0.33.0" }
+sp-core = { default-features = false, version = "29.0.0" }
+sp-inherents = { default-features = false, version = "27.0.0" }
+sp-io = { default-features = false, version = "31.0.0" }
+sp-offchain = { default-features = false, version = "27.0.0" }
+sp-runtime = { default-features = false, version = "32.0.0" }
+sp-session = { default-features = false, version = "28.0.0" }
 sp-std = { default-features = false, version = "14.0.0" }
-sp-transaction-pool = { default-features = false, version = "26.0.0" }
-sp-version = { default-features = false, version = "29.0.0" }
-substrate-wasm-builder = { version = "17.0.0" }
-xcm = { package = "staging-xcm", default-features = false, version = "7.0.0" }
-xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "7.0.0" }
-xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "7.0.0" }
+sp-transaction-pool = { default-features = false, version = "27.0.0" }
+sp-version = { default-features = false, version = "30.0.0" }
+substrate-wasm-builder = { version = "18.0.0" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.0" }
+xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.0" }
+xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.0" }
 
 # std stuff
-cumulus-client-cli = "0.7.0"
-cumulus-client-collator = "0.7.0"
-cumulus-client-consensus-aura = "0.7.0"
-cumulus-client-consensus-common = "0.7.0"
-cumulus-client-consensus-proposer = "0.7.0"
-cumulus-client-consensus-relay-chain = "0.7.0"
-cumulus-client-network = "0.7.0"
-cumulus-client-service = "0.7.0"
-cumulus-primitives-parachain-inherent = "0.7.0"
-cumulus-relay-chain-inprocess-interface = "0.7.0"
-cumulus-relay-chain-interface = "0.7.0"
-cumulus-relay-chain-rpc-interface = "0.7.0"
-frame-benchmarking-cli = "32.0.0"
-pallet-transaction-payment-rpc = "30.0.0"
-polkadot-cli = "7.0.0"
-polkadot-primitives = "7.0.0"
-polkadot-service = "7.0.0"
-sc-basic-authorship = "0.34.0"
-sc-chain-spec = "27.0.0"
-sc-cli = "0.36.0"
-sc-client-api = "28.0.0"
-sc-consensus = "0.33.0"
-sc-executor = "0.32.0"
-sc-network = "0.34.0"
-sc-network-common = "0.33.0"
-sc-network-sync = "0.33.0"
-sc-offchain = "29.0.0"
-sc-rpc = "29.0.0"
-sc-service = "0.35.0"
-sc-sysinfo = "27.0.0"
-sc-telemetry = "15.0.0"
-sc-tracing = "28.0.0"
-sc-transaction-pool = "28.0.0"
-sc-transaction-pool-api = "28.0.0"
-sp-blockchain = "28.0.0"
-sp-consensus = "0.32.0"
-sp-keyring = "31.0.0"
-sp-keystore = "0.34.0"
-sp-timestamp = "26.0.0"
+cumulus-client-cli = "0.8.0"
+cumulus-client-collator = "0.8.0"
+cumulus-client-consensus-aura = "0.8.0"
+cumulus-client-consensus-common = "0.8.0"
+cumulus-client-consensus-proposer = "0.8.0"
+cumulus-client-consensus-relay-chain = "0.8.0"
+cumulus-client-network = "0.8.0"
+cumulus-client-service = "0.8.0"
+cumulus-primitives-parachain-inherent = "0.8.0"
+cumulus-relay-chain-inprocess-interface = "0.8.0"
+cumulus-relay-chain-interface = "0.8.0"
+cumulus-relay-chain-rpc-interface = "0.8.0"
+frame-benchmarking-cli = "33.0.0"
+pallet-transaction-payment-rpc = "31.0.0"
+polkadot-cli = "8.0.0"
+polkadot-primitives = "8.0.1"
+polkadot-service = "8.0.0"
+sc-basic-authorship = "0.35.0"
+sc-chain-spec = "28.0.0"
+sc-cli = "0.37.0"
+sc-client-api = "29.0.0"
+sc-consensus = "0.34.0"
+sc-executor = "0.33.0"
+sc-network = "0.35.0"
+sc-network-common = "0.34.0"
+sc-network-sync = "0.34.0"
+sc-offchain = "30.0.0"
+sc-rpc = "30.0.0"
+sc-service = "0.36.0"
+sc-sysinfo = "28.0.0"
+sc-telemetry = "16.0.0"
+sc-tracing = "29.0.0"
+sc-transaction-pool = "29.0.0"
+sc-transaction-pool-api = "29.0.0"
+sp-blockchain = "29.0.0"
+sp-consensus = "0.33.0"
+sp-keyring = "32.0.0"
+sp-keystore = "0.35.0"
+sp-timestamp = "27.0.0"
 substrate-build-script-utils = "11.0.0"
 substrate-prometheus-endpoint = "0.17.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,27 +25,27 @@ smallvec = "1.11.2"
 tempfile = "3.8.1"
 
 # encointer deps
-encointer-balances-tx-payment = { default-features = false, version = "6.0.0" }
-encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "6.0.0" }
-encointer-primitives = { default-features = false, version = "6.0.1" }
-pallet-encointer-balances = { default-features = false, version = "6.0.0" }
-pallet-encointer-bazaar = { default-features = false, version = "6.0.0" }
-pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, version = "6.0.0" }
-pallet-encointer-ceremonies = { default-features = false, version = "6.0.0" }
-pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, version = "6.0.0" }
-pallet-encointer-communities = { default-features = false, version = "6.0.0" }
-pallet-encointer-communities-rpc-runtime-api = { default-features = false, version = "6.0.0" }
-pallet-encointer-faucet = { default-features = false, version = "6.0.0" }
-pallet-encointer-reputation-commitments = { default-features = false, version = "6.0.0" }
-pallet-encointer-scheduler = { default-features = false, version = "6.0.0" }
+encointer-balances-tx-payment = { default-features = false, version = "~6.0.0" }
+encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
+encointer-primitives = { default-features = false, version = "~6.0.2" }
+pallet-encointer-balances = { default-features = false, version = "~6.0.0" }
+pallet-encointer-bazaar = { default-features = false, version = "~6.0.0" }
+pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
+pallet-encointer-ceremonies = { default-features = false, version = "~6.0.0" }
+pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
+pallet-encointer-communities = { default-features = false, version = "~6.0.0" }
+pallet-encointer-communities-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
+pallet-encointer-faucet = { default-features = false, version = "~6.0.0" }
+pallet-encointer-reputation-commitments = { default-features = false, version = "~6.0.0" }
+pallet-encointer-scheduler = { default-features = false, version = "~6.0.0" }
 # rpc [std]
-pallet-encointer-bazaar-rpc = "6.0.0"
-pallet-encointer-ceremonies-rpc = "6.0.0"
-pallet-encointer-communities-rpc = "6.0.0"
+pallet-encointer-bazaar-rpc = "~6.0.0"
+pallet-encointer-ceremonies-rpc = "~6.0.0"
+pallet-encointer-communities-rpc = "~6.0.0"
 
-# fellowship runtimes
-kusama-runtime-constants = { default-features = false, git = "https://github.com/encointer/runtimes.git", branch = "bkontur/bko-bump-to-1.7" }
-parachain-runtime = { package = "encointer-kusama-runtime", git = "https://github.com/encointer/runtimes.git", branch = "bkontur/bko-bump-to-1.7" }
+# fellowship runtimes. do not depend on fellow-runtimes directly, so we can upgrade at our own pace
+kusama-runtime-constants = { default-features = false, git = "https://github.com/encointer/runtimes.git", branch = "polkadot-v1.7.0" }
+parachain-runtime = { package = "encointer-kusama-runtime", git = "https://github.com/encointer/runtimes.git", branch = "polkadot-v1.7.0" }
 
 # polkadot-sdk [no_std]
 cumulus-pallet-aura-ext = { default-features = false, version = "0.8.0" }
@@ -96,7 +96,7 @@ sp-std = { default-features = false, version = "14.0.0" }
 sp-transaction-pool = { default-features = false, version = "27.0.0" }
 sp-version = { default-features = false, version = "30.0.0" }
 substrate-wasm-builder = { version = "18.0.0" }
-xcm = { package = "staging-xcm", default-features = false, version = "8.0.0" }
+xcm = { package = "staging-xcm", default-features = false, version = "8.0.1" }
 xcm-builder = { package = "staging-xcm-builder", default-features = false, version = "8.0.0" }
 xcm-executor = { package = "staging-xcm-executor", default-features = false, version = "8.0.0" }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "encointer-collator"
-# align major.minor revision with the runtimes. bump patch revision ad lib. make this the github release tag
-version = "1.7.0"
+# align major.minor revision with the polkadot-sdk release. bump patch revision ad lib. make this the github release tag
+version = "1.7.3"
 authors = ["Encointer <info@encointer.org>"]
 build = "build.rs"
 edition = "2021"

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -5,7 +5,6 @@
 
 #![warn(missing_docs)]
 
-use sc_client_api::AuxStore;
 use std::sync::Arc;
 
 use parachain_runtime::{AccountId, AssetBalance, AssetId, Balance, BlockNumber, Moment, Nonce};
@@ -41,7 +40,6 @@ pub fn create_full<C, P, TBackend>(
 where
 	C: ProvideRuntimeApi<Block>
 		+ HeaderBackend<Block>
-		+ AuxStore
 		+ HeaderMetadata<Block, Error = BlockChainError>
 		+ Send
 		+ Sync


### PR DESCRIPTION
simply bump crate versions.

* checked sdk releases 1.7.1 and 1.7.2 too, but they are relaychain-only and not relevant for paras

changing versioning policy now:
* align major.minor with polkadot-sdk release
* bump patch revision ad lib.

this shall be 1.7.3 (the leap to 3 should avoid confusion with patch releases of sdk)
