### PR TITLE
upgrade pallets to 6.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2800,9 +2800,7 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encointer-balances-tx-payment"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bab150ba5131d8e59e861d21b900d123cc55604160c118fb8b2293af5a40d3a"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2817,9 +2815,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1086972f2ea49903c0f7051ec6ad0180e81df47c2b6699f1ff279afba749bba6"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2831,9 +2827,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-ceremonies-assignment"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ebd5dc49f5f6fb321b2e7315bf29e26f3d5f38a1e344f36213137e58fbd54ea"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -2927,7 +2921,6 @@ dependencies = [
 [[package]]
 name = "encointer-kusama-runtime"
 version = "1.0.0"
-source = "git+https://github.com/encointer/runtimes.git?branch=polkadot-v1.7.0#956696788dcb3a8afcaceaf3c3440d781ce2bc82"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -3002,9 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-meetup-validation"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa8b43179179d387317d14bd69335aafb7663f49b77203950fe4deadf1439ed7"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -3016,9 +3007,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-primitives"
-version = "6.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4d3adcceca350eed739e9677fae4e1bea6c7ad526eee456ca30037cbcfe9b9a"
+version = "6.1.0"
 dependencies = [
  "bs58 0.5.0",
  "crc",
@@ -3037,9 +3026,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-rpc"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f527e58caeeb9089d630ecaed587d44d07264aa72e2e7f893e57f5382539dc5d"
+version = "6.1.0"
 dependencies = [
  "jsonrpsee",
  "jsonrpsee-core",
@@ -3112,8 +3099,6 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 [[package]]
 name = "ep-core"
 version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b20f3b698c54e106bcb0533055bf99d64ae9c53261e7ed24366d1ca729a1259"
 dependencies = [
  "array-bytes 6.1.0",
  "impl-serde",
@@ -6591,9 +6576,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-balances"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e315674885628d9255be6ef76d3a50ef5dbaeaa377955d683754d5b6552a49"
+version = "6.1.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -6611,9 +6594,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ef596e3cd3ef64c238452dbed148a6f021a1861ad9917183099b9ed59c2e55"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -6629,9 +6610,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c4d18ee1163ab7c4d42f75d0347295809029c034bfec64545decd6b34cb5c5c"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -6650,9 +6629,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef7ad75291b1b151855c615a5cf4036f1468e22d635585f412d10e0453a94948"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -6663,9 +6640,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91d55a3cd08fdce58f6a92b373decc3709e5908f490a6e2e59aee7036776a64b"
+version = "6.1.0"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-meetup-validation",
@@ -6689,9 +6664,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf43efe76294b07e3157f4a8fabc65002c12a606c0626c922c5f389eb524108"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -6710,9 +6683,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a7655dd964c160eef8af3cc90a8acb235a4695530ff8e81df5176fd34107b84"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -6723,9 +6694,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4163b2b572515e0424d80deef6582e0b8663f75de2058394700ff0a1f7f5dd2f"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -6743,9 +6712,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities-rpc"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603c12e535de2f9616f4f3c5cf2d1baa96a68dca06fb90955674b10a08288f86"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -6765,9 +6732,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc071c9227da132fe57ad496e615695ebcd6a892cc5d2a66d79eb4c3fac5902a"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -6777,9 +6742,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-faucet"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e8faead921402e8ebd73272054a0974af2526e30e74bfb43fccb077aa93149"
+version = "6.1.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -6799,9 +6762,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-reputation-commitments"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5777f365c18c93579880107b08299e77c85254076501130891a71b9be018690a"
+version = "6.1.0"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -6822,9 +6783,7 @@ dependencies = [
 
 [[package]]
 name = "pallet-encointer-scheduler"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26dc40684ab501ad233e5e6da4215a546392b503837a004d97153c482aaa561c"
+version = "6.1.0"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -15080,3 +15039,11 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
+
+[[patch.unused]]
+name = "encointer-balances-tx-payment-rpc"
+version = "6.1.0"
+
+[[patch.unused]]
+name = "kusama-runtime-constants"
+version = "1.0.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-collator"
-version = "1.7.3"
+version = "1.7.4"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-collator"
-version = "1.7.3"
+version = "1.7.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "encointer-kusama-runtime"
 version = "1.0.0"
-source = "git+https://github.com/encointer/runtimes.git?branch=polkadot-v1.7.0#956696788dcb3a8afcaceaf3c3440d781ce2bc82"
+source = "git+https://github.com/encointer/runtimes.git?branch=bkontur/bko-bump-to-1.7#817f944fbf3ffb9fe582e57aa897c3b2dcd4f616"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -7579,9 +7579,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "8.0.2"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32aa4911002f03a8aebd897e094980e7a9fb25d092e0f8db38e76e1e4f643ee"
+checksum = "2b0bade2eb6ce40af35a5af150692b4e150638f7f68c15735ab9cdf79650d68e"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -12822,9 +12822,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "8.0.1"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48fa328b87de3466bc38cc9a07244c42c647b7755b81115e1dfeb47cc13fc6e6"
+checksum = "5ccecaeae5eca8453760e96fcf65481b19898459971842004732e88cd3570741"
 dependencies = [
  "array-bytes 6.1.0",
  "bounded-collections",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,7 +2927,7 @@ dependencies = [
 [[package]]
 name = "encointer-kusama-runtime"
 version = "1.0.0"
-source = "git+https://github.com/encointer/runtimes.git?branch=bkontur/bko-bump-to-1.7#817f944fbf3ffb9fe582e57aa897c3b2dcd4f616"
+source = "git+https://github.com/encointer/runtimes.git?branch=polkadot-v1.7.0#956696788dcb3a8afcaceaf3c3440d781ce2bc82"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -7579,9 +7579,9 @@ dependencies = [
 
 [[package]]
 name = "pallet-xcm"
-version = "8.0.1"
+version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0bade2eb6ce40af35a5af150692b4e150638f7f68c15735ab9cdf79650d68e"
+checksum = "d32aa4911002f03a8aebd897e094980e7a9fb25d092e0f8db38e76e1e4f643ee"
 dependencies = [
  "bounded-collections",
  "frame-benchmarking",
@@ -12822,9 +12822,9 @@ dependencies = [
 
 [[package]]
 name = "staging-xcm"
-version = "8.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ccecaeae5eca8453760e96fcf65481b19898459971842004732e88cd3570741"
+checksum = "48fa328b87de3466bc38cc9a07244c42c647b7755b81115e1dfeb47cc13fc6e6"
 dependencies = [
  "array-bytes 6.1.0",
  "bounded-collections",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,6 +2801,8 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 [[package]]
 name = "encointer-balances-tx-payment"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be09b48ab6e4cdf6316cd3faf036940c4517d149499f07c9e3ddfb70dcc71488"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2816,6 +2818,8 @@ dependencies = [
 [[package]]
 name = "encointer-balances-tx-payment-rpc-runtime-api"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "817560882892e4527f08b152a300772057317725a335e15ce654a07adb60d9d8"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -2828,6 +2832,8 @@ dependencies = [
 [[package]]
 name = "encointer-ceremonies-assignment"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06fb1e51610f1aedf130a9909977943e75de4d44218c60fc73f78b8b410ef872"
 dependencies = [
  "encointer-primitives",
  "sp-runtime",
@@ -2921,6 +2927,7 @@ dependencies = [
 [[package]]
 name = "encointer-kusama-runtime"
 version = "1.0.0"
+source = "git+https://github.com/encointer/runtimes.git?branch=ab/upgrade-encointer-to-6.1#0a0a852720ff945c1f8b0f7b0233be5f062b5b9c"
 dependencies = [
  "cumulus-pallet-aura-ext",
  "cumulus-pallet-dmp-queue",
@@ -2996,6 +3003,8 @@ dependencies = [
 [[package]]
 name = "encointer-meetup-validation"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f7840e8d6e88ac1f2393f6cf5003471663585f8c43d94b26c2e3d4376248148"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -3008,6 +3017,8 @@ dependencies = [
 [[package]]
 name = "encointer-primitives"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4b67ace89f88af02b70f36c8668222bcfc3ac0cac48ac92007ed1218a7643e"
 dependencies = [
  "bs58 0.5.0",
  "crc",
@@ -3027,6 +3038,8 @@ dependencies = [
 [[package]]
 name = "encointer-rpc"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2dd4255adcf89012e75724cc404000c9008bfe4d59eae12691b153fd87191e0"
 dependencies = [
  "jsonrpsee",
  "jsonrpsee-core",
@@ -3099,6 +3112,8 @@ checksum = "e48c92028aaa870e83d51c64e5d4e0b6981b360c522198c23959f219a4e1b15b"
 [[package]]
 name = "ep-core"
 version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b20f3b698c54e106bcb0533055bf99d64ae9c53261e7ed24366d1ca729a1259"
 dependencies = [
  "array-bytes 6.1.0",
  "impl-serde",
@@ -6577,6 +6592,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-balances"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb968c2b87c3ef3ef67e5da9237b6c9b32218762b9e69bf523ddea4f55a5f260"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -6595,6 +6612,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1a4f6a43dce9ec7470ce65716b7009e86eda70f18e3f7690a4841a05d471f10"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -6611,6 +6630,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f6c04106fbea30496065f4fb6dab694d2ab302dbe2ac1fce102e71002843a90"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -6630,6 +6651,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-bazaar-rpc-runtime-api"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "430c3a5bcaa9d2fd7ab314b8e50222c8645699b3157448eabed64b65ad4cf801"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -6641,6 +6664,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87c965513d515c8b74d1d526f999d58aad713462887e290c5295ae2ca13f4b97"
 dependencies = [
  "encointer-ceremonies-assignment",
  "encointer-meetup-validation",
@@ -6665,6 +6690,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf89bf4659e84301332b12fd11688f4e8798b804a83c5701dae78bcb65fb4b68"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -6684,6 +6711,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-ceremonies-rpc-runtime-api"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562c6c756d356318dead2e90710b1c7cee12a6e2ff9aa555e6782ba5202fcde0"
 dependencies = [
  "encointer-primitives",
  "frame-support",
@@ -6695,6 +6724,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efdbb9bac32cd764992ced4055e76c6d09907f5ac3863d1d19f14edda7eaa3ac"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -6713,6 +6744,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53da1621388859e89f8b067dca9ca6dcf587755b81ca9c455e7cc3332a8d2f3d"
 dependencies = [
  "encointer-primitives",
  "encointer-rpc",
@@ -6733,6 +6766,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-communities-rpc-runtime-api"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c10de1b47024c9c7a957521eb29edcf7c9cf31d8c70eee7e991d11f43d137606"
 dependencies = [
  "encointer-primitives",
  "parity-scale-codec",
@@ -6743,6 +6778,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-faucet"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef912a2cdd0f586054d5df1078037ef324fd64515671d6630cfbd1787c4ebe2a"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -6763,6 +6800,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-reputation-commitments"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9029fcdd0cd76e41d067bcf7f09860b4018de9c5382ab1b8006823e2fa148ac5"
 dependencies = [
  "approx",
  "encointer-primitives",
@@ -6784,6 +6823,8 @@ dependencies = [
 [[package]]
 name = "pallet-encointer-scheduler"
 version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13047a59df28111d0e6bd64ca45fa95fe1b97021ba244fe3f7fe3a2edbf2e2c"
 dependencies = [
  "encointer-primitives",
  "frame-benchmarking",
@@ -15039,11 +15080,3 @@ dependencies = [
  "libc",
  "pkg-config",
 ]
-
-[[patch.unused]]
-name = "encointer-balances-tx-payment-rpc"
-version = "6.1.0"
-
-[[patch.unused]]
-name = "kusama-runtime-constants"
-version = "1.0.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2842,7 +2842,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-collator"
-version = "1.7.0"
+version = "1.7.3"
 dependencies = [
  "assert_cmd",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ pallet-encointer-ceremonies-rpc = "~6.1.0"
 pallet-encointer-communities-rpc = "~6.1.0"
 
 # fellowship runtimes. do not depend on fellow-runtimes directly, so we can upgrade at our own pace
-kusama-runtime-constants = { default-features = false, git = "https://github.com/encointer/runtimes.git", branch = "polkadot-v1.7.0" }
-parachain-runtime = { package = "encointer-kusama-runtime", git = "https://github.com/encointer/runtimes.git", branch = "polkadot-v1.7.0" }
+kusama-runtime-constants = { default-features = false, git = "https://github.com/encointer/runtimes.git", branch = "ab/upgrade-encointer-to-6.1" }
+parachain-runtime = { package = "encointer-kusama-runtime", git = "https://github.com/encointer/runtimes.git", branch = "ab/upgrade-encointer-to-6.1" }
 
 # polkadot-sdk [no_std]
 cumulus-pallet-aura-ext = { default-features = false, version = "0.8.0" }
@@ -143,28 +143,28 @@ sp-timestamp = "27.0.0"
 substrate-build-script-utils = "11.0.0"
 substrate-prometheus-endpoint = "0.17.0"
 
-#only while debugging/developping
-[patch."https://github.com/encointer/runtimes"]
-kusama-runtime-constants = { path = "../runtimes/relay/kusama/constants" }
-parachain-runtime = { package = "encointer-kusama-runtime", path = "../runtimes/system-parachains/encointer" }
-
-[patch.crates-io]
-encointer-balances-tx-payment = { path = "../pallets/balances-tx-payment" }
-encointer-balances-tx-payment-rpc = { path = "../pallets/balances-tx-payment/rpc" }
-encointer-balances-tx-payment-rpc-runtime-api = { path = "../pallets/balances-tx-payment/rpc/runtime-api" }
-encointer-ceremonies-assignment = { path = "../pallets/ceremonies/assignment" }
-encointer-primitives = { path = "../pallets/primitives" }
-pallet-encointer-ceremonies = { path = "../pallets/ceremonies" }
-pallet-encointer-ceremonies-rpc = { path = "../pallets/ceremonies/rpc" }
-pallet-encointer-ceremonies-rpc-runtime-api = { path = "../pallets/ceremonies/rpc/runtime-api" }
-pallet-encointer-communities = { path = "../pallets/communities" }
-pallet-encointer-communities-rpc = { path = "../pallets/communities/rpc" }
-pallet-encointer-communities-rpc-runtime-api = { path = "../pallets/communities/rpc/runtime-api" }
-pallet-encointer-balances = { path = "../pallets/balances" }
-pallet-encointer-scheduler = { path = "../pallets/scheduler" }
-pallet-encointer-bazaar = { path = "../pallets/bazaar" }
-pallet-encointer-bazaar-rpc = { path = "../pallets/bazaar/rpc" }
-pallet-encointer-bazaar-rpc-runtime-api = { path = "../pallets/bazaar/rpc/runtime-api" }
-pallet-encointer-faucet = { path = "../pallets/faucet" }
-pallet-encointer-reputation-commitments = { path = "../pallets/reputation-commitments" }
+# ### only while debugging/developping
+#[patch."https://github.com/encointer/runtimes"]
+#kusama-runtime-constants = { path = "../runtimes/relay/kusama/constants" }
+#parachain-runtime = { package = "encointer-kusama-runtime", path = "../runtimes/system-parachains/encointer" }
+#
+#[patch.crates-io]
+#encointer-balances-tx-payment = { path = "../pallets/balances-tx-payment" }
+#encointer-balances-tx-payment-rpc = { path = "../pallets/balances-tx-payment/rpc" }
+#encointer-balances-tx-payment-rpc-runtime-api = { path = "../pallets/balances-tx-payment/rpc/runtime-api" }
+#encointer-ceremonies-assignment = { path = "../pallets/ceremonies/assignment" }
+#encointer-primitives = { path = "../pallets/primitives" }
+#pallet-encointer-ceremonies = { path = "../pallets/ceremonies" }
+#pallet-encointer-ceremonies-rpc = { path = "../pallets/ceremonies/rpc" }
+#pallet-encointer-ceremonies-rpc-runtime-api = { path = "../pallets/ceremonies/rpc/runtime-api" }
+#pallet-encointer-communities = { path = "../pallets/communities" }
+#pallet-encointer-communities-rpc = { path = "../pallets/communities/rpc" }
+#pallet-encointer-communities-rpc-runtime-api = { path = "../pallets/communities/rpc/runtime-api" }
+#pallet-encointer-balances = { path = "../pallets/balances" }
+#pallet-encointer-scheduler = { path = "../pallets/scheduler" }
+#pallet-encointer-bazaar = { path = "../pallets/bazaar" }
+#pallet-encointer-bazaar-rpc = { path = "../pallets/bazaar/rpc" }
+#pallet-encointer-bazaar-rpc-runtime-api = { path = "../pallets/bazaar/rpc/runtime-api" }
+#pallet-encointer-faucet = { path = "../pallets/faucet" }
+#pallet-encointer-reputation-commitments = { path = "../pallets/reputation-commitments" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,23 +25,23 @@ smallvec = "1.11.2"
 tempfile = "3.8.1"
 
 # encointer deps
-encointer-balances-tx-payment = { default-features = false, version = "~6.0.0" }
-encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
-encointer-primitives = { default-features = false, version = "~6.0.2" }
-pallet-encointer-balances = { default-features = false, version = "~6.0.0" }
-pallet-encointer-bazaar = { default-features = false, version = "~6.0.0" }
-pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
-pallet-encointer-ceremonies = { default-features = false, version = "~6.0.0" }
-pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
-pallet-encointer-communities = { default-features = false, version = "~6.0.0" }
-pallet-encointer-communities-rpc-runtime-api = { default-features = false, version = "~6.0.0" }
-pallet-encointer-faucet = { default-features = false, version = "~6.0.0" }
-pallet-encointer-reputation-commitments = { default-features = false, version = "~6.0.0" }
-pallet-encointer-scheduler = { default-features = false, version = "~6.0.0" }
+encointer-balances-tx-payment = { default-features = false, version = "~6.1.0" }
+encointer-balances-tx-payment-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
+encointer-primitives = { default-features = false, version = "~6.1.0" }
+pallet-encointer-balances = { default-features = false, version = "~6.1.0" }
+pallet-encointer-bazaar = { default-features = false, version = "~6.1.0" }
+pallet-encointer-bazaar-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
+pallet-encointer-ceremonies = { default-features = false, version = "~6.1.0" }
+pallet-encointer-ceremonies-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
+pallet-encointer-communities = { default-features = false, version = "~6.1.0" }
+pallet-encointer-communities-rpc-runtime-api = { default-features = false, version = "~6.1.0" }
+pallet-encointer-faucet = { default-features = false, version = "~6.1.0" }
+pallet-encointer-reputation-commitments = { default-features = false, version = "~6.1.0" }
+pallet-encointer-scheduler = { default-features = false, version = "~6.1.0" }
 # rpc [std]
-pallet-encointer-bazaar-rpc = "~6.0.0"
-pallet-encointer-ceremonies-rpc = "~6.0.0"
-pallet-encointer-communities-rpc = "~6.0.0"
+pallet-encointer-bazaar-rpc = "~6.1.0"
+pallet-encointer-ceremonies-rpc = "~6.1.0"
+pallet-encointer-communities-rpc = "~6.1.0"
 
 # fellowship runtimes. do not depend on fellow-runtimes directly, so we can upgrade at our own pace
 kusama-runtime-constants = { default-features = false, git = "https://github.com/encointer/runtimes.git", branch = "polkadot-v1.7.0" }
@@ -143,44 +143,28 @@ sp-timestamp = "27.0.0"
 substrate-build-script-utils = "11.0.0"
 substrate-prometheus-endpoint = "0.17.0"
 
-
 #only while debugging/developping
-#[patch."https://github.com/encointer/pallets"]
-#encointer-balances-tx-payment = { path = "../pallets/balances-tx-payment" }
-#encointer-balances-tx-payment-rpc = { path = "../pallets/balances-tx-payment/rpc" }
-#encointer-balances-tx-payment-rpc-runtime-api = { path = "../pallets/balances-tx-payment/rpc/runtime-api" }
-#encointer-ceremonies-assignment = { path = "../pallets/ceremonies/assignment" }
-#encointer-primitives = { path = "../pallets/primitives" }
-#pallet-encointer-ceremonies = { path = "../pallets/ceremonies" }
-#pallet-encointer-ceremonies-rpc = { path = "../pallets/ceremonies/rpc" }
-#pallet-encointer-ceremonies-rpc-runtime-api = { path = "../pallets/ceremonies/rpc/runtime-api" }
-#pallet-encointer-communities = { path = "../pallets/communities" }
-#pallet-encointer-communities-rpc = { path = "../pallets/communities/rpc" }
-#pallet-encointer-communities-rpc-runtime-api = { path = "../pallets/communities/rpc/runtime-api" }
-#pallet-encointer-balances = { path = "../pallets/balances" }
-#pallet-encointer-scheduler = { path = "../pallets/scheduler" }
-#pallet-encointer-bazaar = { path = "../pallets/bazaar" }
-#pallet-encointer-bazaar-rpc = { path = "../pallets/bazaar/rpc" }
-#pallet-encointer-bazaar-rpc-runtime-api = { path = "../pallets/bazaar/rpc/runtime-api" }
+[patch."https://github.com/encointer/runtimes"]
+kusama-runtime-constants = { path = "../runtimes/relay/kusama/constants" }
+parachain-runtime = { package = "encointer-kusama-runtime", path = "../runtimes/system-parachains/encointer" }
 
-#only while debugging/developping
-#[patch.crates-io]
-#encointer-balances-tx-payment = { path = "../pallets/balances-tx-payment" }
-#encointer-balances-tx-payment-rpc = { path = "../pallets/balances-tx-payment/rpc" }
-#encointer-balances-tx-payment-rpc-runtime-api = { path = "../pallets/balances-tx-payment/rpc/runtime-api" }
-#encointer-ceremonies-assignment = { path = "../pallets/ceremonies/assignment" }
-#encointer-primitives = { path = "../pallets/primitives" }
-#pallet-encointer-ceremonies = { path = "../pallets/ceremonies" }
-#pallet-encointer-ceremonies-rpc = { path = "../pallets/ceremonies/rpc" }
-#pallet-encointer-ceremonies-rpc-runtime-api = { path = "../pallets/ceremonies/rpc/runtime-api" }
-#pallet-encointer-communities = { path = "../pallets/communities" }
-#pallet-encointer-communities-rpc = { path = "../pallets/communities/rpc" }
-#pallet-encointer-communities-rpc-runtime-api = { path = "../pallets/communities/rpc/runtime-api" }
-#pallet-encointer-balances = { path = "../pallets/balances" }
-#pallet-encointer-scheduler = { path = "../pallets/scheduler" }
-#pallet-encointer-bazaar = { path = "../pallets/bazaar" }
-#pallet-encointer-bazaar-rpc = { path = "../pallets/bazaar/rpc" }
-#pallet-encointer-bazaar-rpc-runtime-api = { path = "../pallets/bazaar/rpc/runtime-api" }
-#pallet-encointer-faucet = { path = "../pallets/faucet" }
-#pallet-encointer-reputation-commitments = { path = "../pallets/reputation-commitments" }
-#
+[patch.crates-io]
+encointer-balances-tx-payment = { path = "../pallets/balances-tx-payment" }
+encointer-balances-tx-payment-rpc = { path = "../pallets/balances-tx-payment/rpc" }
+encointer-balances-tx-payment-rpc-runtime-api = { path = "../pallets/balances-tx-payment/rpc/runtime-api" }
+encointer-ceremonies-assignment = { path = "../pallets/ceremonies/assignment" }
+encointer-primitives = { path = "../pallets/primitives" }
+pallet-encointer-ceremonies = { path = "../pallets/ceremonies" }
+pallet-encointer-ceremonies-rpc = { path = "../pallets/ceremonies/rpc" }
+pallet-encointer-ceremonies-rpc-runtime-api = { path = "../pallets/ceremonies/rpc/runtime-api" }
+pallet-encointer-communities = { path = "../pallets/communities" }
+pallet-encointer-communities-rpc = { path = "../pallets/communities/rpc" }
+pallet-encointer-communities-rpc-runtime-api = { path = "../pallets/communities/rpc/runtime-api" }
+pallet-encointer-balances = { path = "../pallets/balances" }
+pallet-encointer-scheduler = { path = "../pallets/scheduler" }
+pallet-encointer-bazaar = { path = "../pallets/bazaar" }
+pallet-encointer-bazaar-rpc = { path = "../pallets/bazaar/rpc" }
+pallet-encointer-bazaar-rpc-runtime-api = { path = "../pallets/bazaar/rpc/runtime-api" }
+pallet-encointer-faucet = { path = "../pallets/faucet" }
+pallet-encointer-reputation-commitments = { path = "../pallets/reputation-commitments" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,4 +167,3 @@ substrate-prometheus-endpoint = "0.17.0"
 #pallet-encointer-bazaar-rpc-runtime-api = { path = "../pallets/bazaar/rpc/runtime-api" }
 #pallet-encointer-faucet = { path = "../pallets/faucet" }
 #pallet-encointer-reputation-commitments = { path = "../pallets/reputation-commitments" }
-

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "encointer-collator"
 # align major.minor revision with the polkadot-sdk release. bump patch revision ad lib. make this the github release tag
-version = "1.7.3"
+version = "1.7.4"
 authors = ["Encointer <info@encointer.org>"]
 build = "build.rs"
 edition = "2021"


### PR DESCRIPTION
alongside https://github.com/polkadot-fellows/runtimes/pull/236

bump node to 1.7.4