### PR TITLE
adding stkd bootnodes for encointer-kusama.json

### DIFF
--- a/node/res/encointer-kusama.json
+++ b/node/res/encointer-kusama.json
@@ -21,7 +21,8 @@
     "/dns/encointer-kusama.bootnodes.polkadotters.com/tcp/30535/p2p/12D3KooWNRWrCQJ2HKHhJr7hkqdYQKsUCTUrugXKmv4fk6Ee19mg",
     "/dns/encointer-kusama.bootnodes.polkadotters.com/tcp/30537/wss/p2p/12D3KooWNRWrCQJ2HKHhJr7hkqdYQKsUCTUrugXKmv4fk6Ee19mg",
     "/dns/encointer-kusama.boot.stake.plus/tcp/30332/wss/p2p/12D3KooWBUH8j2WbtHA8XXfzPVBTDsdzYXhvEwuLtQeJ3mJ463aP",
-    "/dns/encointer-kusama.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWPc12uKhwWNrpxr4H6ezQCfXJDsLP7BkS2xHvbgD1DC9G"
+    "/dns/encointer-kusama.boot.stake.plus/tcp/31332/wss/p2p/12D3KooWPc12uKhwWNrpxr4H6ezQCfXJDsLP7BkS2xHvbgD1DC9G",
+    "/dns/encointer-kusama-01.bootnode.stkd.io/tcp/30633/wss/p2p/12D3KooWHufqTF69nkDBuGutABsxCyM9KDVrz9uJrCX5c2Gqr19t"
   ],
   "chainType": "Live",
   "codeSubstitutes": {},


### PR DESCRIPTION
Hey,

Opening this PR to add our bootnodes for the IBP. This node is located in Santiago Chile, we own and manage the underlying hardware. If you need any more information please let me know.


```
docker run -it \
  -v $(pwd)/encointer-kusama.json:/chainSpec.json \
  --platform=linux/amd64 \
  --rm encointer/parachain:1.14.0 \ 
  --chain /chainSpec.json \
  --reserved-only \
  --reserved-nodes "/dns/encointer-kusama-01.bootnode.stkd.io/tcp/30633/wss/p2p/12D3KooWHufqTF69nkDBuGutABsxCyM9KDVrz9uJrCX5c2Gqr19t"
```
