### PR TITLE
[Dockerfile] add root CAs to the Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM phusion/baseimage:focal-1.0.0
 LABEL description="This is the 2nd stage: a very small image where we copy the Substrate binary."
 
 RUN apt-get update && \
-apt-get install -y jq
+apt-get install -y jq ca-certificates
 
 RUN mv /usr/share/ca* /tmp && \
 	rm -rf /usr/share/*  && \


### PR DESCRIPTION
Not sure if we use the Dockerbuild anywhere, but this fix is necessary so that the node does not complain about missing root CAs since polkadot-stable202412