### PR TITLE
Bump Ubuntu in Dockerfile and add a minimal Docker build integration CI test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,6 +228,28 @@ jobs:
             -u ws://host.docker.internal \
             --port 9944 \
 
+  docker-build:
+    name: docker-build
+    runs-on: ubuntu-22.04
+    needs: build_primary_binaries
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download Encointer Collator
+        uses: actions/download-artifact@v4
+        with:
+          name: encointer-collator-${{ github.sha }}
+          # for debugging the integration tests, we can just download an image from a previous run
+      #          name: encointer-collator-859e7ba3e64e971a91b1174a4d9423bb854be9d9
+      #          github-token: ${{ github.token }}
+      #          run-id: 12904591738
+
+      - name: fix permissions of artifacts
+        run: |
+          chmod +x encointer-collator 
+
+      - name: Docker build
+        run: Docker build .
 
   release:
     name: Draft Release

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,7 +249,7 @@ jobs:
           chmod +x encointer-collator 
 
       - name: Docker build
-        run: Docker build .
+        run: docker build .
 
   release:
     name: Draft Release

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM phusion/baseimage:focal-1.0.0
+FROM phusion/baseimage:jammy-1.0.4
 LABEL description="This is the 2nd stage: a very small image where we copy the Substrate binary."
 
 RUN apt-get update && \


### PR DESCRIPTION
It was not the first time that a release failed because we missed that the docker build is broken. Hence, I added a minimal CI test