### PR TITLE
v1.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3561,7 +3561,7 @@ dependencies = [
 
 [[package]]
 name = "encointer-collator"
-version = "1.18.0"
+version = "1.20.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "encointer-collator"
 # align major.minor revision with the polkadot-sdk release. bump patch revision ad lib. make this the github release tag
-version = "1.18.0"
+version = "1.20.0"
 authors = ["Encointer <info@encointer.org>"]
 build = "build.rs"
 edition = "2021"


### PR DESCRIPTION
v1.20.0 is not an official polkadot release yet. v1.19.0 is stable 2506, and we are now using unstable 2507 - hence I went for v1.20.0 as we did with the pallets.