### PR TITLE
Fix getting the parachain id when syncing from genesis

### DIFF
--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -273,8 +273,10 @@ pub async fn start_parachain_node(
 	let transaction_pool = params.transaction_pool.clone();
 	let import_queue_service = params.import_queue.service();
 
-	// Take parachain id from runtime or fall back to the old extensions one.
-	// This is needed if the chain syncs from scratch.
+	// Take parachain id from runtime or fall back to the old mechanism fetching it from the `Extension`.
+	//
+	// The fallback is needed if some old chain syncs from scratch, where the runtime
+	// api does not yet implement
 	let best_hash = client.chain_info().best_hash;
 	let para_id = if client
 		.runtime_api()


### PR DESCRIPTION
The reason for this bug was that the parachain template upstream does not properly handle the case if there is no `GetParachainInfo` runtime api available. Which prevents syncing from scratch, as our old runtime did not have this. We do it now the same way as the omni node handles it by falling back to the extension approach. Closes #249.

Tested that it works from scratch now.